### PR TITLE
ci: cache CI build jobs (clippy/test/regression); release build left pristine

### DIFF
--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -45,7 +45,27 @@ runs:
       # Cargo.toml (`pgrx = "0.16"`). The default fallback (0.17)
       # diverges from the runtime version and ICEs at init time
       # (see specs/ERRATA.v0.2.md E-006 for pgrx 0.17+ status).
-      run: cargo install cargo-pgrx --locked --version "^${PGRX_VERSION:-0.16}"
+      #
+      # The crates.io index fetch intermittently fails with
+      # `curl ... [16] Error in the HTTP2 framing layer` on GitHub
+      # runners (a transient HTTP/2 flake, not a real error). Forcing
+      # HTTP/1.1 sidesteps that class; CARGO_NET_RETRY + the outer loop
+      # cover any residual transient. Mirrors the postgres-image pull
+      # retry already used in ci.yml's regression job.
+      env:
+        CARGO_HTTP_MULTIPLEXING: "false"
+        CARGO_NET_RETRY: "5"
+      run: |
+        set -euo pipefail
+        for i in 1 2 3 4 5; do
+          if cargo install cargo-pgrx --locked --version "^${PGRX_VERSION:-0.16}"; then
+            exit 0
+          fi
+          echo "cargo install cargo-pgrx attempt $i failed; retrying after backoff"
+          sleep $((i * 10))
+        done
+        echo "::error::cargo install cargo-pgrx failed after 5 attempts"
+        exit 1
 
     - name: cargo pgrx init
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with: { components: clippy }
+      # CI-only build cache (cargo registry + ./target + the cargo-pgrx
+      # binary), keyed per PG major. Placed before setup-pgrx so its
+      # `cargo install cargo-pgrx` becomes a fast no-op on a cache hit.
+      # The release.yml build matrix is deliberately LEFT UNCACHED so the
+      # attested release bytes always come from a clean-room compile.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: "pg${{ matrix.pg }}"
+          cache-on-failure: true
       - uses: ./.github/actions/setup-pgrx
         with: { pg: "${{ matrix.pg }}" }
       - run: cargo clippy --no-default-features --features pg${{ matrix.pg }} -- -D warnings
@@ -50,6 +59,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      # CI-only build cache (see the clippy job for rationale). Release
+      # build matrix stays uncached.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: "pg${{ matrix.pg }}"
+          cache-on-failure: true
       - uses: ./.github/actions/setup-pgrx
         with: { pg: "${{ matrix.pg }}" }
       - run: cargo pgrx test --no-default-features --features pg${{ matrix.pg }} pg${{ matrix.pg }}
@@ -78,13 +93,23 @@ jobs:
           DOCKER_BUILDKIT: "1"
         run: |
           set -euo pipefail
+          # CI-only GitHub Actions layer cache (type=gha). The builder's
+          # pre-`COPY . .` layers — apt deps, `cargo install cargo-pgrx`,
+          # `cargo pgrx init` — are reused across pushes; the final
+          # `cargo pgrx package` still re-runs when source changes (its
+          # cargo cache mount is build-scoped, not exported). Release
+          # build artifacts are produced by release.yml, which is NOT
+          # cached, so attested bytes stay clean-room.
           docker build --target builder \
             -t pgrdf-builder-rust:pg17 \
             --build-arg PG_MAJOR=17 \
+            --cache-from type=gha,scope=pgrdf-builder-pg17 \
             -f compose/builder.Containerfile .
           docker build \
             -t pgrdf-builder:pg17 \
             --build-arg PG_MAJOR=17 \
+            --cache-from type=gha,scope=pgrdf-builder-pg17 \
+            --cache-to type=gha,mode=max,scope=pgrdf-builder-pg17 \
             -f compose/builder.Containerfile .
           rm -rf compose/extensions/lib compose/extensions/share
           mkdir -p compose/extensions/lib compose/extensions/share/extension


### PR DESCRIPTION
Follows the "reasonable split": **cache the CI lane, keep the release build pristine.**

## What

- **`clippy` + `test`** — `Swatinem/rust-cache@v2` (caches cargo registry, `./target`, and the `cargo-pgrx` binary), keyed per PG major, placed *before* `setup-pgrx` so its `cargo install cargo-pgrx` is a near no-op on a cache hit. Biggest win — that compile is paid on every run today.
- **`regression`** — `type=gha` layer cache on the two `builder.Containerfile` docker builds. The expensive setup layers (apt deps, `cargo install cargo-pgrx`, `cargo pgrx init`) all sit **before** `COPY . .`, so they're reused across pushes. Honest limitation: the final `cargo pgrx package` still recompiles when source changes — its cargo cache is a build-scoped `--mount=type=cache`, which `type=gha` doesn't export. (A cargo-chef restructure would cache the dep compile too — separate, larger change.)

## What is NOT cached (on purpose)

`release.yml`'s `build` matrix. Those are the bytes that get SLSA-attested and booted by the new pre-attest gate, so they always come from a clean-room compile. Caching CI but not release is the whole point of the split.

## Notes

- Per-job + per-PG cache keys (`key: pg<major>`) so the matrix restore stays correct when pg14/15/16 come back.
- GHA cache budget is 10 GB/repo shared across caches; clippy + test + the builder cache should sit comfortably under that. If eviction ever churns, the builder `type=gha` cache is the first to drop.
- CI-only change; no source, no release/attestation path touched.
