### PR TITLE
ci: skip the heavy jobs on docs-only changes (paths-ignore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,27 @@
 name: ci
 on:
+  # Docs-only changes skip CI entirely — a markdown / docs / license edit must
+  # not trigger the full fmt + clippy + test + ~9-min regression build. main is
+  # not branch-protected (CI is advisory), so a skipped run does not block merge.
+  # A PR that touches ANY non-ignored path (code, SQL, compose, Cargo*, etc.)
+  # still runs the full suite — so release PRs keep their boot+version gate.
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'guide/**'
+      - 'specs/**'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'guide/**'
+      - 'specs/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Fixes #27. A docs-only PR (PROVENANCE / README / CHANGELOG / guide / specs) no longer triggers fmt + clippy + test + the ~9-min regression build.

`ci.yml` now has `paths-ignore` (`**/*.md`, `docs/**`, `guide/**`, `specs/**`, `LICENSE`, `.gitignore`) on both `pull_request` and `push: main`. Because `main` is **not** branch-protected, a skipped CI run does not block merge — a markdown change is just cheap + quiet now.

Any PR that touches a non-ignored path (code, SQL, compose, `Cargo*`, etc.) still runs the **full** suite — so release PRs keep their boot+version reconciliation gate. This PR itself touches a workflow file, so it runs CI once; the saving applies to future docs PRs.