### PR TITLE
ci: draft-aware builds — drafts run fmt+clippy, Ready runs the full suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,18 @@
 name: ci
 on:
-  # Docs-only changes skip CI entirely — a markdown / docs / license edit must
-  # not trigger the full fmt + clippy + test + ~9-min regression build. main is
-  # not branch-protected (CI is advisory), so a skipped run does not block merge.
-  # A PR that touches ANY non-ignored path (code, SQL, compose, Cargo*, etc.)
-  # still runs the full suite — so release PRs keep their boot+version gate.
+  # Two cost controls keep CI cheap until it needs to be thorough:
+  #  1. Docs-only changes skip CI entirely (paths-ignore below) — a markdown /
+  #     docs / license edit must not trigger the fmt + clippy + test + ~9-min
+  #     regression build. main is not branch-protected (CI is advisory), so a
+  #     skipped run does not block merge.
+  #  2. Draft PRs run only the light between-commit checks (fmt + clippy). The
+  #     heavy `test` + `regression` jobs are gated (see their `if:`) to run only
+  #     when the PR is marked Ready for review, or on a push to main. Flipping a
+  #     draft to Ready re-triggers CI via the `ready_for_review` type below and
+  #     kicks off the full suite. A non-docs Ready PR (code, SQL, compose,
+  #     Cargo*, …) runs everything — so release PRs keep their boot+version gate.
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -66,6 +73,9 @@ jobs:
 
   test:
     runs-on: ubuntu-22.04
+    # Heavy job — runs on pushes to main and on Ready (non-draft) PRs only.
+    # Draft PRs skip it and get fmt + clippy as the between-commit signal.
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
@@ -101,6 +111,8 @@ jobs:
   regression:
     runs-on: ubuntu-22.04
     needs: test
+    # Same draft gate as `test` (which it needs) — Ready PRs + main pushes only.
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     env:
       PGRDF_CONTAINER: pgrdf-pgrdf-postgres
     steps:


### PR DESCRIPTION
## What

Make CI cost-aware of PR **draft** status, matching the agreed working model:

- **Draft PR** → only the light between-commit checks run: **fmt** (~8s) + **clippy** (~1.6m).
- **Flip to Ready for review** → the full suite kicks in: **test** + the ~9-min **regression** (compose: SPARQL / SHACL Core 25/25 / SHACL-SPARQL / LUBM gates).
- **Push to main** → full suite, unchanged.

A full release is unaffected — it stays **tag-only** (`release.yml` on `push: tags: ['v*']`). This PR changes only *which checks run on a PR*, never *when a release is cut*.

## How

- `pull_request` trigger gains `types: [opened, synchronize, reopened, ready_for_review]` so flipping a draft → Ready re-triggers CI.
- `test` and `regression` get `if: github.event_name == 'push' || github.event.pull_request.draft == false`.
- `fmt` + `clippy` stay ungated → they run on drafts too.
- Existing `paths-ignore` (docs-only skip) is untouched.

## Dogfood

This PR is itself a **draft**, so on `ci` it should show **fmt + clippy only** — `test` and `regression` skipped. Flip it to **Ready for review** to watch the full suite kick in, then it is ready to merge.
