### PR TITLE
feat(carve): fail-closed on path-depth / closure truncation (#14)

### DIFF
--- a/docs/03-query.md
+++ b/docs/03-query.md
@@ -270,6 +270,30 @@ path the guard actually cut bumps it); it may benignly over-count
 when the cut node was already reached by a shorter path (LLD v0.4
 §7.2 explicitly permits this).
 
+**`pgrdf.on_path_truncation` GUC — fail-closed truncation (#14).**
+String, `GucContext::Userset`, one of `'count' | 'warn' | 'error'`,
+default **`warn`**. The counter above is cumulative and
+cross-backend, so on its own a truncated walk is invisible to the
+caller that ran it; this GUC upgrades the per-query signal:
+
+* `count` — bump the counter only (the pre-#14 silent behaviour).
+* `warn` (default) — counter **plus a client-visible `WARNING`** per
+  truncated walk: a partial result is never silent.
+* `error` — **fail the query** (stable prefix `sparql: property path
+  truncated at pgrdf.path_max_depth=N`) instead of returning a
+  depth-truncated result. The fail-closed mode for closure queries —
+  e.g. an un-materialised `rdfs:subClassOf*` type-closure walk whose
+  under-collection would silently propagate into a carve slice.
+
+An unrecognised value warns and behaves as `warn` (a typo never
+*loosens* the policy to silent). Companion carve-side report: the
+neighbourhood `carve_graph` counts the **boundary** (distinct nodes
+one edge beyond the `max_hops` rim that the cap kept out of the
+slice) in the same statement and reports a non-zero boundary via
+`NOTICE` — `max_hops` legitimately *defines* the slice, so a
+continuing neighbourhood is a report, not an error. Regression
+`140-truncation-fail-closed.sql` locks all four behaviours.
+
 **`|` alternation (E4).** `?s (a|b) ?o` is the union of the
 per-predicate scans — equivalently a single scan over the predicate
 **set** (`predicate_id IN (a, b)`). It is a **non-reflexive single

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -6622,6 +6622,25 @@ fn execute(plan: &ExecPlan) -> Vec<pgrx::JsonB> {
                 .unwrap_or(0);
             if hit != 0 {
                 crate::storage::shmem_cache::note_path_depth_truncation();
+                // Issue #14 — fail-closed truncation. The counter is
+                // cumulative and cross-backend, so on its own a
+                // truncated walk is invisible to the caller that ran
+                // it; `pgrdf.on_path_truncation` upgrades the signal.
+                match crate::query::guc::on_path_truncation() {
+                    crate::query::guc::OnPathTruncation::Count => {}
+                    crate::query::guc::OnPathTruncation::Warn => pgrx::warning!(
+                        "sparql: property path truncated at pgrdf.path_max_depth={} — \
+                         longer paths are missing from this result; raise \
+                         pgrdf.path_max_depth, or SET pgrdf.on_path_truncation = 'error' \
+                         to forbid partial results",
+                        crate::query::guc::path_max_depth()
+                    ),
+                    crate::query::guc::OnPathTruncation::Error => panic!(
+                        "sparql: property path truncated at pgrdf.path_max_depth={} \
+                         (pgrdf.on_path_truncation=error forbids partial results)",
+                        crate::query::guc::path_max_depth()
+                    ),
+                }
             }
         }
         rows
@@ -12721,6 +12740,63 @@ mod tests {
              (got {trunc_after})"
         );
         Spi::run("RESET pgrdf.path_max_depth").unwrap();
+    }
+
+    /// Issue #14 — `pgrdf.on_path_truncation = 'error'` fails the
+    /// query instead of returning a depth-truncated partial result
+    /// (the fail-closed mode for closure walks feeding a carve).
+    #[pg_test(
+        error = "sparql: property path truncated at pgrdf.path_max_depth=2 (pgrdf.on_path_truncation=error forbids partial results)"
+    )]
+    fn path_truncation_error_mode_fails_closed() {
+        Spi::run(
+            "SELECT pgrdf.parse_turtle(
+                '@prefix ex: <http://example.com/> .
+                 ex:t1 ex:sub ex:t2 . ex:t2 ex:sub ex:t3 .
+                 ex:t3 ex:sub ex:t4 . ex:t4 ex:sub ex:t5 .',
+                9203)",
+        )
+        .unwrap();
+        Spi::run("SET pgrdf.path_max_depth = 2").unwrap();
+        Spi::run("SET pgrdf.on_path_truncation = 'error'").unwrap();
+        Spi::run(
+            "SELECT count(*) FROM pgrdf.sparql(
+                 'PREFIX ex: <http://example.com/> \
+                  SELECT ?o WHERE { ex:t1 ex:sub+ ?o }')",
+        )
+        .unwrap();
+    }
+
+    /// Issue #14 — `'count'` restores the pre-#14 silent behaviour:
+    /// truncated rows come back, only the counter moves. Locks the
+    /// GUC parse arm and that `error` mode is genuinely opt-in.
+    #[pg_test]
+    fn path_truncation_count_mode_returns_truncated_rows() {
+        Spi::run(
+            "SELECT pgrdf.parse_turtle(
+                '@prefix ex: <http://example.com/> .
+                 ex:u1 ex:sub ex:u2 . ex:u2 ex:sub ex:u3 .
+                 ex:u3 ex:sub ex:u4 . ex:u4 ex:sub ex:u5 .',
+                9204)",
+        )
+        .unwrap();
+        Spi::run("SET pgrdf.path_max_depth = 2").unwrap();
+        Spi::run("SET pgrdf.on_path_truncation = 'count'").unwrap();
+        Spi::run("SELECT pgrdf.shmem_reset()").unwrap();
+        let n: i64 = Spi::get_one(
+            "SELECT count(*)::bigint FROM pgrdf.sparql(
+                 'PREFIX ex: <http://example.com/> \
+                  SELECT ?o WHERE { ex:u1 ex:sub+ ?o }')",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(n, 2, "cap 2 over a length-4 chain → u2, u3 only");
+        let trunc: i64 = Spi::get_one("SELECT (pgrdf.stats()->>'path_depth_truncations')::bigint")
+            .unwrap()
+            .unwrap();
+        assert!(trunc > 0, "count mode still bumps the counter");
+        Spi::run("RESET pgrdf.path_max_depth").unwrap();
+        Spi::run("RESET pgrdf.on_path_truncation").unwrap();
     }
 
     /// E3 invariant A in miniature — `*` is the reflexive-transitive

--- a/src/query/guc.rs
+++ b/src/query/guc.rs
@@ -35,6 +35,28 @@ pub(crate) const MAX_PATH_MAX_DEPTH: i32 = 1024;
 /// affects that session's query plans, never another backend).
 pub(crate) static PATH_MAX_DEPTH: GucSetting<i32> = GucSetting::<i32>::new(DEFAULT_PATH_MAX_DEPTH);
 
+/// `pgrdf.on_path_truncation` — what a query does when a recursive
+/// property-path walk (`+` / `*`) actually hits `pgrdf.path_max_depth`
+/// (issue #14, fail-closed truncation; detected by the per-`+`
+/// truncation probe, so a cycle that terminates naturally never
+/// triggers it):
+///
+/// * `count` — the pre-#14 behaviour: bump the cumulative
+///   `pgrdf.stats().path_depth_truncations` counter and return the
+///   (depth-limited) rows silently.
+/// * `warn` (default) — `count` plus a client-visible WARNING per
+///   truncated walk, so a partial result is never silent.
+/// * `error` — fail the query with a stable-prefix error instead of
+///   returning a partial result. The fail-closed mode for closure
+///   queries (e.g. an un-materialised `rdfs:subClassOf*` type-closure
+///   walk feeding a carve) where under-collection would silently
+///   propagate into a curated slice.
+///
+/// An unrecognised value logs a warning and behaves as `warn` (the
+/// default — honest but non-fatal).
+pub(crate) static ON_PATH_TRUNCATION: GucSetting<Option<CString>> =
+    GucSetting::<Option<CString>>::new(Some(c"warn"));
+
 // ─────────────────────────────────────────────────────────────────────
 // TA-7 — dict-path GUCs
 // ─────────────────────────────────────────────────────────────────────
@@ -224,6 +246,21 @@ pub fn register() {
         GucFlags::default(),
     );
     GucRegistry::define_string_guc(
+        c"pgrdf.on_path_truncation",
+        c"Behaviour when a property-path walk hits pgrdf.path_max_depth.",
+        c"One of 'count' | 'warn' | 'error'. 'count' silently bumps \
+          pgrdf.stats().path_depth_truncations (the pre-#14 \
+          behaviour); 'warn' (default) additionally raises a \
+          client-visible WARNING per truncated walk so a partial \
+          result is never silent; 'error' fails the query instead of \
+          returning a depth-truncated result — the fail-closed mode \
+          for closure queries feeding a carve. An unrecognised value \
+          logs a warning and behaves as 'warn'.",
+        &ON_PATH_TRUNCATION,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_string_guc(
         c"pgrdf.ingest_dict_path",
         c"Dict-resolution path used by parse_turtle / load_turtle.",
         c"One of 'baseline' | 'batched' | 'shmem_warm' | 'combined'. \
@@ -358,6 +395,36 @@ pub(crate) fn ingest_dict_path() -> IngestDictPath {
 /// `ANALYZE` after writing inferred triples (M1; default on).
 pub(crate) fn auto_analyze() -> bool {
     AUTO_ANALYZE.get()
+}
+
+/// Parsed `pgrdf.on_path_truncation` policy (issue #14).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum OnPathTruncation {
+    /// Bump `path_depth_truncations` only (silent; pre-#14 behaviour).
+    Count,
+    /// Counter + a client-visible WARNING per truncated walk.
+    Warn,
+    /// Fail the query rather than return a depth-truncated result.
+    Error,
+}
+
+/// Resolved `pgrdf.on_path_truncation` for this session. An
+/// unrecognised value warns (once per read) and behaves as `Warn` —
+/// the default is already the honest mode, so a typo never *loosens*
+/// the policy to silent.
+pub(crate) fn on_path_truncation() -> OnPathTruncation {
+    let raw = ON_PATH_TRUNCATION.get();
+    match raw.as_ref().and_then(|c| c.to_str().ok()) {
+        Some("count") => OnPathTruncation::Count,
+        Some("warn") | None => OnPathTruncation::Warn,
+        Some("error") => OnPathTruncation::Error,
+        Some(other) => {
+            pgrx::warning!(
+                "pgrdf.on_path_truncation: unrecognised value '{other}' — behaving as 'warn'"
+            );
+            OnPathTruncation::Warn
+        }
+    }
 }
 
 /// Resolved `pgrdf.dict_batch_size` for this call. Returns at least

--- a/src/storage/graphs.rs
+++ b/src/storage/graphs.rs
@@ -868,7 +868,16 @@ fn carve_graph_neighbourhood(
     // endpoints in the frontier). One set-based statement; the data-modifying
     // `ins` CTE's RETURNING feeds the inserted count. Result is identical to the
     // prior OR form (regression 137/138/139); only the plan changes.
-    let count: i64 = Spi::get_one_with_args(
+    // Issue #14 (§4b.3 "report what it dropped"): the same statement also
+    // counts the BOUNDARY — distinct nodes one edge past the hop-cap rim
+    // that the cap kept out of the slice. Computed from the `frontier`
+    // rows at `hop = $2` with the same split-union index-only edge
+    // expansion as the hop walk (never an `OR`), so it costs one extra
+    // rim expansion, not a second BFS. A non-zero boundary is REPORTED
+    // via NOTICE — `max_hops` legitimately *defines* the slice (a K-hop
+    // ball), so a continuing neighbourhood is not an error; a silent
+    // partial closure is.
+    let (count, boundary): (Option<i64>, Option<i64>) = Spi::get_two_with_args(
         &format!(
             "WITH RECURSIVE frontier(node_id, hop) AS ( \
                  SELECT id, 0 FROM pgrdf._pgrdf_dictionary \
@@ -894,13 +903,31 @@ fn carve_graph_neighbourhood(
                  WHERE q.object_id IN (SELECT node_id FROM nodes) \
                    AND q.subject_id NOT IN (SELECT node_id FROM nodes) \
                  RETURNING 1 \
+             ), \
+             boundary AS ( \
+                 SELECT count(DISTINCT e.to_node)::bigint AS n \
+                 FROM (SELECT node_id FROM frontier WHERE hop = $2) rim \
+                 JOIN ( SELECT subject_id AS from_node, object_id AS to_node FROM pgrdf.{src_name} \
+                        UNION ALL \
+                        SELECT object_id AS from_node, subject_id AS to_node FROM pgrdf.{src_name} ) e \
+                   ON e.from_node = rim.node_id \
+                 WHERE e.to_node NOT IN (SELECT node_id FROM nodes) \
              ) \
-             SELECT count(*)::bigint FROM ins"
+             SELECT (SELECT count(*)::bigint FROM ins), (SELECT n FROM boundary)"
         ),
         &[seed_iris.into(), hops.into()],
     )
-    .unwrap_or_else(|e| panic!("carve_graph: neighbourhood carve failed: {e}"))
-    .unwrap_or(0);
+    .unwrap_or_else(|e| panic!("carve_graph: neighbourhood carve failed: {e}"));
+    let count = count.unwrap_or(0);
+    let boundary = boundary.unwrap_or(0);
+
+    if boundary > 0 {
+        pgrx::notice!(
+            "carve_graph: neighbourhood continues beyond max_hops={hops} — {boundary} adjacent \
+             node(s) were not expanded; the slice is the requested {hops}-hop ball, not a closed \
+             component (raise max_hops to widen)"
+        );
+    }
 
     count
 }
@@ -1976,6 +2003,40 @@ mod tests {
         let _ = Spi::get_one::<i64>(
             "SELECT pgrdf.move_graph('http://example.org/missing-src', \
                                      'http://example.org/g7-mv-dst')",
+        );
+    }
+
+    /// Issue #14 — the boundary-report CTE must not change carve
+    /// results. Chain a—b—c: a 1-hop carve from `a` reaches nodes
+    /// {a,b}, extracts BOTH edges (b→c rides its subject), and has a
+    /// boundary of exactly {c} (reported via NOTICE — text locked by
+    /// regression 140); a 2-hop carve closes the component (boundary
+    /// 0, no NOTICE) with the same quad count.
+    #[pg_test]
+    fn carve_neighbourhood_boundary_report_count_invariant() {
+        Spi::run("SELECT pgrdf.add_graph(9310)").unwrap();
+        Spi::run(
+            "SELECT pgrdf.parse_turtle(
+                '@prefix ex: <http://example.com/> .
+                 ex:a ex:p ex:b . ex:b ex:p ex:c .',
+                9310)",
+        )
+        .unwrap();
+        let one_hop: i64 =
+            Spi::get_one("SELECT pgrdf.carve_graph(9310, ARRAY['http://example.com/a'], 9311, 1)")
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            one_hop, 2,
+            "1-hop ball {{a,b}} extracts both edges (b→c via its subject)"
+        );
+        let two_hop: i64 =
+            Spi::get_one("SELECT pgrdf.carve_graph(9310, ARRAY['http://example.com/a'], 9312, 2)")
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            two_hop, 2,
+            "2-hop closes the component — same quads, boundary 0"
         );
     }
 }

--- a/tests/regression/expected/109-property-path-plus.out
+++ b/tests/regression/expected/109-property-path-plus.out
@@ -34,9 +34,11 @@ http://example.org/c
 
 10
 0
+WARNING:  sparql: property path truncated at pgrdf.path_max_depth=3 — longer paths are missing from this result; raise pgrdf.path_max_depth, or SET pgrdf.on_path_truncation = 'error' to forbid partial results
 http://example.org/c2
 http://example.org/c3
 http://example.org/c4
+WARNING:  sparql: property path truncated at pgrdf.path_max_depth=3 — longer paths are missing from this result; raise pgrdf.path_max_depth, or SET pgrdf.on_path_truncation = 'error' to forbid partial results
 3
 t
 

--- a/tests/regression/expected/110-property-path-star-opt.out
+++ b/tests/regression/expected/110-property-path-star-opt.out
@@ -63,10 +63,12 @@ http://example.org/c
 
 11
 0
+WARNING:  sparql: property path truncated at pgrdf.path_max_depth=3 — longer paths are missing from this result; raise pgrdf.path_max_depth, or SET pgrdf.on_path_truncation = 'error' to forbid partial results
 http://example.org/c1
 http://example.org/c2
 http://example.org/c3
 http://example.org/c4
+WARNING:  sparql: property path truncated at pgrdf.path_max_depth=3 — longer paths are missing from this result; raise pgrdf.path_max_depth, or SET pgrdf.on_path_truncation = 'error' to forbid partial results
 4
 t
 

--- a/tests/regression/expected/138-carve-graph-neighbourhood.out
+++ b/tests/regression/expected/138-carve-graph-neighbourhood.out
@@ -3,13 +3,18 @@
 t
 8
 src_quads_8: true
+NOTICE:  carve_graph: neighbourhood continues beyond max_hops=0 — 3 adjacent node(s) were not expanded; the slice is the requested 0-hop ball, not a closed component (raise max_hops to widen)
 carve_0hop_returns_3: true
 dst201_quads_3: true
+NOTICE:  carve_graph: neighbourhood continues beyond max_hops=1 — 3 adjacent node(s) were not expanded; the slice is the requested 1-hop ball, not a closed component (raise max_hops to widen)
 carve_1hop_returns_6: true
 dst202_quads_6: true
+NOTICE:  carve_graph: neighbourhood continues beyond max_hops=2 — 2 adjacent node(s) were not expanded; the slice is the requested 2-hop ball, not a closed component (raise max_hops to widen)
 carve_2hop_returns_8: true
 carve_unknown_returns_0: true
+NOTICE:  carve_graph: neighbourhood continues beyond max_hops=0 — 5 adjacent node(s) were not expanded; the slice is the requested 0-hop ball, not a closed component (raise max_hops to widen)
 carve_multiseed_returns_6: true
+NOTICE:  carve_graph: neighbourhood continues beyond max_hops=1 — 3 adjacent node(s) were not expanded; the slice is the requested 1-hop ball, not a closed component (raise max_hops to widen)
 carve_default_hop_returns_6: true
 src_unchanged_8: true
 dict_unchanged_14: true

--- a/tests/regression/expected/139-carve-guards.out
+++ b/tests/regression/expected/139-carve-guards.out
@@ -24,6 +24,7 @@ inferred_carried_to_slice_1: true
 t
 2
 blanknode_src_2: true
+NOTICE:  carve_graph: neighbourhood continues beyond max_hops=1 — 1 adjacent node(s) were not expanded; the slice is the requested 1-hop ball, not a closed component (raise max_hops to widen)
 nbhd_blanknode_1hop_2: true
 blanknode_slice_has_y: true
 

--- a/tests/regression/expected/140-truncation-fail-closed.out
+++ b/tests/regression/expected/140-truncation-fail-closed.out
@@ -1,0 +1,14 @@
+NOTICE:  extension "pgrdf" already exists, skipping
+t
+4
+warn
+WARNING:  sparql: property path truncated at pgrdf.path_max_depth=2 — longer paths are missing from this result; raise pgrdf.path_max_depth, or SET pgrdf.on_path_truncation = 'error' to forbid partial results
+warn_rows_2: true
+error_mode_fails_closed: t
+error_mode_undercap_ok_4: true
+count_rows_2: true
+t
+2
+NOTICE:  carve_graph: neighbourhood continues beyond max_hops=1 — 1 adjacent node(s) were not expanded; the slice is the requested 1-hop ball, not a closed component (raise max_hops to widen)
+carve_1hop_2: true
+carve_2hop_2: true

--- a/tests/regression/run.sh
+++ b/tests/regression/run.sh
@@ -51,9 +51,20 @@ for sql in "${tests[@]}"; do
 
   # `-X` skips ~/.psqlrc; `-A` unaligned; `-t` tuples-only; `-q` quiet;
   # `-v ON_ERROR_STOP=1` so first error halts the script for that file.
-  actual="$("${RUNTIME}" exec -i "${CONTAINER}" \
-    psql -U "${PSQL_USER}" -d "${PSQL_DB}" \
-    -X -A -t -q -v ON_ERROR_STOP=1 < "${sql}" 2>&1)" || true
+  #
+  # Message-vs-row ordering (#14): goldens capture NOTICE/WARNING lines,
+  # so their position must be deterministic. Two raciness sources fixed
+  # here: (1) `2>&1` must happen INSIDE the container — `docker exec`
+  # carries stdout and stderr as separately-multiplexed streams, so a
+  # host-side merge interleaves them in arrival order (observed flapping,
+  # even mid-line); (2) `stdbuf -o0 -e0` write-through, since psql's
+  # stdout is block-buffered into a pipe while stderr is not. Merged
+  # in-container and unbuffered, the order is psql's program order:
+  # a statement's messages print during result consumption, BEFORE its
+  # rows.
+  actual="$("${RUNTIME}" exec -i "${CONTAINER}" sh -c \
+    "stdbuf -o0 -e0 psql -U '${PSQL_USER}' -d '${PSQL_DB}' \
+     -X -A -t -q -v ON_ERROR_STOP=1 2>&1" < "${sql}")" || true
 
   if [ ! -f "${expected}" ] || [ "${ACCEPT}" = "1" ]; then
     printf '%s\n' "${actual}" > "${expected}"

--- a/tests/regression/sql/140-truncation-fail-closed.sql
+++ b/tests/regression/sql/140-truncation-fail-closed.sql
@@ -1,0 +1,66 @@
+-- 140-truncation-fail-closed.sql — #14 fail-closed truncation reporting
+--
+-- Locks the pgrdf.on_path_truncation policy surface and the carve boundary
+-- report: (1) the default 'warn' emits a client-visible WARNING when a
+-- property-path walk is cut at pgrdf.path_max_depth (a partial result is
+-- never silent); (2) 'error' fails the query with the stable prefix instead
+-- of returning a truncated result; (3) 'count' restores the pre-#14 silent
+-- counter-only behaviour; (4) the neighbourhood carve reports its
+-- unexpanded boundary via NOTICE, with count semantics unchanged
+-- (companion to 137/138/139).
+--
+-- ZERO-FOOTPRINT by construction: the 31+-era tests inherit the
+-- lexically-previous test's leftover state into their `SELECT ?s ?p ?o`
+-- counts, and this file sorts right before them — so everything here runs
+-- inside BEGIN…ROLLBACK (no DROP EXTENSION, no shmem_reset, no residue),
+-- and every assertion is scoped to this file's own unique terms/graphs.
+
+SET client_min_messages = NOTICE;
+CREATE EXTENSION IF NOT EXISTS pgrdf;
+
+BEGIN;
+
+SELECT pgrdf.add_graph(91400);
+SELECT pgrdf.parse_turtle('@prefix ex: <http://pgrdf-140.test/> . ex:c1 ex:sub ex:c2 . ex:c2 ex:sub ex:c3 . ex:c3 ex:sub ex:c4 . ex:c4 ex:sub ex:c5 .', 91400);
+
+-- ── (1) default policy is 'warn': depth-limited rows + a WARNING ──────────
+SHOW pgrdf.on_path_truncation;
+SET pgrdf.path_max_depth = 2;
+SELECT 'warn_rows_2: ' || (count(*) = 2) FROM pgrdf.sparql('PREFIX ex: <http://pgrdf-140.test/> SELECT ?o WHERE { ex:c1 ex:sub+ ?o }');
+
+-- ── (2) 'error' fails closed (trapped: ON_ERROR_STOP would halt the file) ──
+SET pgrdf.on_path_truncation = 'error';
+CREATE OR REPLACE FUNCTION pg_temp._trunc_raises() RETURNS TEXT LANGUAGE plpgsql AS $$
+DECLARE msg TEXT;
+BEGIN
+  BEGIN
+    PERFORM count(*) FROM pgrdf.sparql('PREFIX ex: <http://pgrdf-140.test/> SELECT ?o WHERE { ex:c1 ex:sub+ ?o }');
+    RETURN 'error_mode_fails_closed: !!! unexpected success !!!';
+  EXCEPTION WHEN OTHERS THEN msg := SQLERRM;
+  END;
+  IF position('forbids partial results' IN msg) > 0 THEN RETURN 'error_mode_fails_closed: t';
+  ELSE RETURN 'error_mode_fails_closed: f (' || left(msg, 80) || ')'; END IF;
+END $$;
+SELECT pg_temp._trunc_raises();
+
+-- an under-cap walk must NOT error even in 'error' mode (no false positive)
+SET pgrdf.path_max_depth = 64;
+SELECT 'error_mode_undercap_ok_4: ' || (count(*) = 4) FROM pgrdf.sparql('PREFIX ex: <http://pgrdf-140.test/> SELECT ?o WHERE { ex:c1 ex:sub+ ?o }');
+
+-- ── (3) 'count' is the silent pre-#14 behaviour, opt-in ───────────────────
+SET pgrdf.path_max_depth = 2;
+SET pgrdf.on_path_truncation = 'count';
+SELECT 'count_rows_2: ' || (count(*) = 2) FROM pgrdf.sparql('PREFIX ex: <http://pgrdf-140.test/> SELECT ?o WHERE { ex:c1 ex:sub+ ?o }');
+SET pgrdf.path_max_depth = 64;
+SET pgrdf.on_path_truncation = 'warn';
+
+-- ── (4) carve boundary report: 1-hop ball from a over a—b—c ───────────────
+-- nodes {a,b} extract BOTH edges (b→c rides its subject); boundary = {c},
+-- reported via NOTICE. The 2-hop carve closes the component: same count,
+-- boundary 0, NO notice.
+SELECT pgrdf.add_graph(91410);
+SELECT pgrdf.parse_turtle('@prefix ex: <http://pgrdf-140.test/> . ex:a ex:p ex:b . ex:b ex:p ex:c .', 91410);
+SELECT 'carve_1hop_2: ' || (pgrdf.carve_graph(91410, ARRAY['http://pgrdf-140.test/a'], 91411, 1) = 2);
+SELECT 'carve_2hop_2: ' || (pgrdf.carve_graph(91410, ARRAY['http://pgrdf-140.test/a'], 91412, 2) = 2);
+
+ROLLBACK;


### PR DESCRIPTION
## What

Closes #14 (SPEC CARVE §4b.3 discipline — *never a silent partial slice*). Based on `main`, independent of the #52/#53 stack.

**New GUC `pgrdf.on_path_truncation`** = `'count' | 'warn' | 'error'` (Userset, default **`warn`**). The truncation probe already detected a depth-cut walk but only bumped a cumulative cross-backend counter — invisible to the caller that ran the query, which is exactly how an un-materialised `rdfs:subClassOf*` closure walk would silently under-collect into a carve slice:
- `count` — the old silent counter-only behaviour, now opt-in
- `warn` (default) — plus a client-visible WARNING per truncated walk
- `error` — fail the query (stable prefix) instead of returning a depth-truncated result; the fail-closed mode for closure queries feeding a carve
- unrecognised values warn and behave as `warn` — a typo never *loosens* the policy to silent

**Neighbourhood carve boundary report** — the carve statement now also counts the **boundary** (distinct nodes one edge beyond the `max_hops` rim that the cap excluded), via the same split-union index-only expansion as the hop walk (one extra rim expansion, no second BFS, never an `OR` — the #32 rule). Non-zero boundary ⇒ NOTICE. `max_hops` legitimately *defines* the slice, so a continuing neighbourhood is a report, not an error. Carve counts unchanged (137/138/139 + a count-invariance pg_test).

## Test-infra fix the goldens exposed

NOTICE/WARNING position in captured regression output was **non-deterministic**: `docker exec` multiplexes stdout/stderr as separate streams (host-side `2>&1` interleaves them in arrival order — observed flapping, even mid-line), and psql block-buffers stdout into a pipe. `run.sh` now merges the streams **inside** the container and runs psql under `stdbuf -o0 -e0` — messages land deterministically before their statement's rows. Verified with 3 consecutive full-suite runs: **100/100 each**.

New regression `140-truncation-fail-closed` locks all four behaviours and is **zero-footprint by construction** (`BEGIN…ROLLBACK`, no `DROP EXTENSION`) — the 31+-era goldens count the lexically-previous test's leftovers, so a new `1xx` test must leave none.

## Verification

| gate | result |
|---|---|
| pgrx suite (pg17 builder container, isolated volume) | 317/317 (3 new) |
| golden regression (isolated container, worktree .so) | 100/100 × 3 consecutive runs |
| W3C harness | 51/51 |
| fmt + clippy `-D warnings` | clean |

Goldens 109/110/138/139 change by **added WARNING/NOTICE lines only** — no value changes. Docs: `docs/03-query.md` GUC section.