### PR TITLE
fix(sparql): CONSTRUCT set semantics (#54) + pre-ship review hardening

### DIFF
--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -1486,6 +1486,10 @@ fn expand_template_per_solution(template_rows: &[Value], n_solutions: usize) -> 
 /// within-solution repeats) dedup. First-occurrence order is
 /// preserved for a deterministic result (the harness sorts anyway).
 fn dedup_construct_rows(rows: Vec<pgrx::JsonB>) -> Vec<pgrx::JsonB> {
+    // Nothing to collapse below two rows — skip the serialize+hash pass.
+    if rows.len() <= 1 {
+        return rows;
+    }
     let mut seen: HashSet<String> = HashSet::with_capacity(rows.len());
     let mut out: Vec<pgrx::JsonB> = Vec::with_capacity(rows.len());
     for row in rows {
@@ -6182,10 +6186,32 @@ fn expr_to_numeric_sql(
                 return None;
             }
             let v = l.value();
-            if v.parse::<f64>().is_err() {
-                return None;
+            let parsed: f64 = match v.parse() {
+                Ok(f) => f,
+                Err(_) => return None,
+            };
+            // XSD admits INF / -INF / NaN as xsd:double / xsd:float
+            // lexemes, and Rust f64::parse accepts them — but the raw
+            // token would emit an unquoted `INF::numeric`, which
+            // Postgres reads as a column reference and aborts the whole
+            // query. Map the non-finite cases to Postgres' quoted
+            // numeric special-value literals (PG14+ numeric supports
+            // Infinity / -Infinity / NaN). Finite values keep their
+            // (safe, unchanged) unquoted lexical form.
+            if parsed.is_nan() {
+                Some("'NaN'::numeric".to_string())
+            } else if parsed.is_infinite() {
+                Some(
+                    if parsed > 0.0 {
+                        "'Infinity'::numeric"
+                    } else {
+                        "'-Infinity'::numeric"
+                    }
+                    .to_string(),
+                )
+            } else {
+                Some(format!("{v}::numeric"))
             }
-            Some(format!("{v}::numeric"))
         }
         // Arithmetic — both sides cast to numeric. NULL propagation
         // means a non-numeric operand drops the row (SPARQL "type
@@ -6274,9 +6300,11 @@ fn expr_to_numeric_sql(
             match (local, args.len()) {
                 ("exp", 1) => {
                     let x = expr_to_numeric_sql(&args[0], anchors)?;
-                    // float8 exp overflows above ln(f64::MAX) ≈ 709.78.
+                    // float8 exp overflows above ln(f64::MAX) ≈ 709.7827;
+                    // guard at 709.78 (exp(709.78) is representable) so
+                    // in-range inputs in (709, 709.78] still evaluate.
                     Some(format!(
-                        "(CASE WHEN {x} <= 709 THEN exp(({x})::float8)::numeric END)"
+                        "(CASE WHEN {x} <= 709.78 THEN exp(({x})::float8)::numeric END)"
                     ))
                 }
                 // math:log is the NATURAL logarithm (XPath F&O §4.8.3).
@@ -6295,9 +6323,17 @@ fn expr_to_numeric_sql(
                 ("pow", 2) => {
                     let x = expr_to_numeric_sql(&args[0], anchors)?;
                     let y = expr_to_numeric_sql(&args[1], anchors)?;
+                    // Guards, in order: 0^negative (undefined), negative
+                    // base to a non-integer exponent (complex result), and
+                    // the OVERFLOW guard — |x|^y overflows float8 when
+                    // y·ln|x| > ln(f64::MAX) ≈ 709.78. Without the last
+                    // arm `power(1e200, 2)` aborts the whole query,
+                    // contradicting this tier's "never a SQL abort"
+                    // contract (the `x <> 0` predicate keeps ln() off 0).
                     Some(format!(
                         "(CASE WHEN ({x}) = 0 AND ({y}) < 0 THEN NULL \
                                WHEN ({x}) < 0 AND ({y}) <> floor({y}) THEN NULL \
+                               WHEN ({x}) <> 0 AND ({y}) * ln(abs(({x})::float8)) > 709.78 THEN NULL \
                                ELSE power(({x})::float8, ({y})::float8)::numeric END)"
                     ))
                 }
@@ -14204,6 +14240,107 @@ mod tests {
         .unwrap()
         .unwrap();
         assert_eq!(sqrt_neg, 1, "sqrt(-4) is unbound, no SQL error");
+    }
+
+    /// Review hardening — `math:pow` overflow must yield UNBOUND, never
+    /// abort the query (the tier's "never a SQL abort" contract).
+    /// `pow(1e200, 2) = 1e400` overflows float8.
+    #[pg_test]
+    fn math_pow_overflow_is_unbound_not_abort() {
+        Spi::run(
+            "SELECT pgrdf.parse_turtle('@prefix ex: <http://ex/> . \
+             ex:big ex:v 1e200 . ex:ok ex:v 3 .', 0)",
+        )
+        .unwrap();
+        // The whole query must evaluate (no abort); the overflow row is
+        // unbound, the in-range row is bound.
+        let unbound: i64 = Spi::get_one(
+            "SELECT count(*)::bigint FROM pgrdf.sparql(
+                 'PREFIX ex: <http://ex/> \
+                  PREFIX math: <http://www.w3.org/2005/xpath-functions/math#> \
+                  SELECT (math:pow(?v, 2) AS ?p) WHERE { ?s ex:v ?v }') AS s(j)
+              WHERE j->>'p' IS NULL",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            unbound, 1,
+            "pow(1e200,2) overflows → unbound, not a SQL abort"
+        );
+        let ok: String = Spi::get_one(
+            "SELECT j->>'p' FROM pgrdf.sparql(
+                 'PREFIX ex: <http://ex/> \
+                  PREFIX math: <http://www.w3.org/2005/xpath-functions/math#> \
+                  SELECT (math:pow(?v, 2) AS ?p) WHERE { ex:ok ex:v ?v }') AS s(j)",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            ok.parse::<f64>().unwrap(),
+            9.0,
+            "in-range pow still evaluates"
+        );
+    }
+
+    /// Review hardening — `math:exp` guard must admit in-range inputs
+    /// up to ~709.78 (ln(f64::MAX)); the old `<= 709` cut off
+    /// representable values like exp(709.5).
+    #[pg_test]
+    fn math_exp_guard_admits_representable() {
+        Spi::run(
+            "SELECT pgrdf.parse_turtle('@prefix ex: <http://ex/> . \
+             ex:a ex:v 709.5 . ex:over ex:v 710 .', 0)",
+        )
+        .unwrap();
+        let bound: String = Spi::get_one(
+            "SELECT j->>'y' FROM pgrdf.sparql(
+                 'PREFIX ex: <http://ex/> \
+                  PREFIX math: <http://www.w3.org/2005/xpath-functions/math#> \
+                  SELECT (math:exp(?v) AS ?y) WHERE { ex:a ex:v ?v }') AS s(j)",
+        )
+        .unwrap()
+        .unwrap();
+        assert!(
+            bound.parse::<f64>().unwrap() > 1.0e307,
+            "exp(709.5) ≈ 1.2e308 is representable and must be bound, got {bound}"
+        );
+        // Genuinely-overflowing input (exp(710) > f64::MAX) is unbound,
+        // not an abort.
+        let over: i64 = Spi::get_one(
+            "SELECT count(*)::bigint FROM pgrdf.sparql(
+                 'PREFIX ex: <http://ex/> \
+                  PREFIX math: <http://www.w3.org/2005/xpath-functions/math#> \
+                  SELECT (math:exp(?v) AS ?y) WHERE { ex:over ex:v ?v }') AS s(j)
+              WHERE j->>'y' IS NULL",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(over, 1, "exp(710) overflows → unbound");
+    }
+
+    /// Review hardening — an `INF` / `-INF` / `NaN` xsd:double constant
+    /// literal in the numeric lane must not abort the query with a
+    /// bogus 'column does not exist' (unquoted `INF::numeric`). A
+    /// finite value compared against `"INF"^^xsd:double` evaluates.
+    #[pg_test]
+    fn numeric_special_double_literal_does_not_abort() {
+        Spi::run(
+            "SELECT pgrdf.parse_turtle('@prefix ex: <http://ex/> . \
+             ex:a ex:v 5 .', 0)",
+        )
+        .unwrap();
+        // ?v < INF is true for every finite ?v → the row survives the
+        // FILTER (and, critically, the query does not abort).
+        let n: i64 = Spi::get_one(
+            "SELECT count(*)::bigint FROM pgrdf.sparql(
+                 'PREFIX ex:  <http://ex/> \
+                  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> \
+                  SELECT ?s WHERE { ?s ex:v ?v \
+                     FILTER(?v < \"INF\"^^xsd:double) }') AS s(j)",
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(n, 1, "?v < INF holds for finite ?v; no SQL abort");
     }
 
     // ── Issue #50: aggregates over expressions + BIND-produced vars ──

--- a/src/query/executor.rs
+++ b/src/query/executor.rs
@@ -523,7 +523,9 @@ fn construct(query: &str) -> SetOfIterator<'static, pgrx::JsonB> {
             let params = params_take();
             let solutions = execute_count_only(&probe, &params);
             let rows = expand_template_per_solution(&template_rows, solutions);
-            return SetOfIterator::new(rows.into_iter());
+            // §16.2 set semantics (#54): a constant template over N
+            // solutions yields N identical triples → one in the graph.
+            return SetOfIterator::new(dedup_construct_rows(rows).into_iter());
         }
         let sql = build_bgp_sql(&ps);
         let truncation_probes = collect_truncation_probes(&ps);
@@ -535,7 +537,7 @@ fn construct(query: &str) -> SetOfIterator<'static, pgrx::JsonB> {
         };
         let solutions = execute(&plan).len();
         let rows = expand_template_per_solution(&template_rows, solutions);
-        return SetOfIterator::new(rows.into_iter());
+        return SetOfIterator::new(dedup_construct_rows(rows).into_iter());
     }
 
     // Per-solution path. Used whenever any template position needs
@@ -549,7 +551,10 @@ fn construct(query: &str) -> SetOfIterator<'static, pgrx::JsonB> {
     // positions of the same solution resolves to the same fresh
     // label (within-solution sameness per SPARQL 1.1 §16.2).
     let rows = execute_construct_per_solution_path(&ps, &slots, &template_vars);
-    SetOfIterator::new(rows.into_iter())
+    // §16.2 set semantics (#54): distinct solutions that produce the
+    // SAME ground triple collapse to one; minted-bnode rows across
+    // solutions differ in their fresh labels and correctly survive.
+    SetOfIterator::new(dedup_construct_rows(rows).into_iter())
 }
 
 /// Build + run the per-solution path. Mirrors the INSERT-WHERE
@@ -1464,6 +1469,33 @@ fn expand_template_per_solution(template_rows: &[Value], n_solutions: usize) -> 
     for _ in 0..n_solutions {
         for row in template_rows {
             out.push(pgrx::JsonB(row.clone()));
+        }
+    }
+    out
+}
+
+/// §16.2 set semantics (issue #54). A CONSTRUCT result is an RDF
+/// **graph** — a *set* of triples — so identical triples produced by
+/// different solutions collapse to one; the solution sequence's
+/// multiplicity does NOT survive into the output graph. Row-level
+/// dedup is exactly right here: a template blank node mints a **fresh
+/// label per solution** (see `construct` / `BNodeMinter`), so two
+/// rows for the "same" template triple across solutions differ in
+/// their minted labels and are genuinely distinct triples (§16.2.1) —
+/// they do not collapse. Only byte-identical rows (ground triples, or
+/// within-solution repeats) dedup. First-occurrence order is
+/// preserved for a deterministic result (the harness sorts anyway).
+fn dedup_construct_rows(rows: Vec<pgrx::JsonB>) -> Vec<pgrx::JsonB> {
+    let mut seen: HashSet<String> = HashSet::with_capacity(rows.len());
+    let mut out: Vec<pgrx::JsonB> = Vec::with_capacity(rows.len());
+    for row in rows {
+        // The encoder builds every row's JSON with the same key
+        // insertion order (subject/predicate/object, then
+        // type/value/datatype/language), so the serialized string is
+        // a stable set key across rows.
+        let key = row.0.to_string();
+        if seen.insert(key) {
+            out.push(row);
         }
     }
     out
@@ -11991,11 +12023,12 @@ mod tests {
         );
     }
 
-    /// Multi-solution path — 3 matches, constant template emits 3
-    /// identical rows (one burst per solution per W3C 1.1 §16.2's
-    /// "solution sequence is the BGP's; multiplicity matters").
+    /// §16.2 set semantics (#54) — a CONSTRUCT result is an RDF graph,
+    /// so a constant template over 3 solutions yields ONE triple, not
+    /// three. The solution sequence's multiplicity does not survive
+    /// into the output graph (a graph cannot hold a triple twice).
     #[pg_test]
-    fn construct_constant_template_three_solutions() {
+    fn construct_constant_template_dedups_to_set() {
         Spi::run(
             "SELECT pgrdf.parse_turtle(
                 '@prefix ex: <http://example.com/> .
@@ -12014,8 +12047,54 @@ mod tests {
         .unwrap()
         .unwrap_or(0);
         assert_eq!(
-            n, 3,
-            "three solutions × one template triple → three identical rows"
+            n, 1,
+            "three solutions × one constant template triple → ONE triple in the graph (§16.2 set)"
+        );
+    }
+
+    /// §16.2 set semantics (#54), the subtle half — distinct solutions
+    /// producing the SAME ground triple collapse to one, but a
+    /// template blank node mints a fresh label per solution, so its
+    /// rows stay distinct (§16.2.1). Here two subjects both map to the
+    /// same constant object triple (collapses) while the bnode arm
+    /// yields one fresh bnode per solution (survives).
+    #[pg_test]
+    fn construct_dedup_collapses_ground_keeps_bnodes() {
+        Spi::run(
+            "SELECT pgrdf.parse_turtle(
+                '@prefix ex: <http://example.com/> .
+                 ex:s1 ex:p ex:shared .
+                 ex:s2 ex:p ex:shared .',
+                9111)",
+        )
+        .unwrap();
+
+        // Ground triple `?o ex:seen true` — both solutions bind ?o to
+        // ex:shared, so the same ground triple twice → ONE.
+        let ground: i64 = Spi::get_one(
+            "SELECT count(*)::BIGINT FROM pgrdf.construct(
+               'CONSTRUCT { ?o <http://example.com/seen> \"true\" } \
+                 WHERE { ?s <http://example.com/p> ?o }')",
+        )
+        .unwrap()
+        .unwrap_or(0);
+        assert_eq!(
+            ground, 1,
+            "same ground triple from 2 solutions collapses to 1"
+        );
+
+        // Blank-node subject `_:b ex:for ?o` — a fresh bnode per
+        // solution → 2 genuinely-distinct triples, no collapse.
+        let bnodes: i64 = Spi::get_one(
+            "SELECT count(*)::BIGINT FROM pgrdf.construct(
+               'CONSTRUCT { _:b <http://example.com/for> ?o } \
+                 WHERE { ?s <http://example.com/p> ?o }')",
+        )
+        .unwrap()
+        .unwrap_or(0);
+        assert_eq!(
+            bnodes, 2,
+            "fresh bnode per solution → distinct triples survive dedup"
         );
     }
 

--- a/tests/oracle/src/run.rs
+++ b/tests/oracle/src/run.rs
@@ -93,7 +93,16 @@ pub fn run(cfg: &Config) -> Result<Totals, String> {
         let test_dir = cfg.fixtures_dir.join(name);
         let gid = graph_id_for(name);
         let sql = assemble_sql(&test_dir, &gid).map_err(|e| format!("{name}: {e}"))?;
-        let raw = engine(&cfg.engine_cmd, &sql)?;
+        let (raw, engine_ok) = engine(&cfg.engine_cmd, &sql)?;
+        if !engine_ok {
+            // psql exited non-zero under ON_ERROR_STOP=1 — the fixture's
+            // SQL errored. Hard FAIL regardless of golden/oracle (never
+            // baseline it either): otherwise an erroring zero-result
+            // fixture matches an empty golden and reads as green.
+            println!("  {RED}FAIL{RESET}     {name} (engine SQL error — psql exited non-zero; see stderr)");
+            t.fail += 1;
+            continue;
+        }
         let actual = normalize(&raw);
 
         // Differential oracle pass. BEFORE the baseline branch on
@@ -239,12 +248,15 @@ fn assemble_sql(test_dir: &Path, gid: &str) -> Result<String, String> {
     Ok(sql)
 }
 
-/// Pipe the SQL stream to the engine command's stdin, return stdout.
-/// The engine's exit status is deliberately ignored (matching the
-/// bash harness): a psql SQL error yields partial output that the
-/// golden diff then reports — the failure surfaces where the
-/// evidence is.
-fn engine(engine_cmd: &str, sql: &str) -> Result<String, String> {
+/// Pipe the SQL stream to the engine command's stdin; return its stdout
+/// and whether psql exited 0. The exit status matters: run.sh drives
+/// psql with `ON_ERROR_STOP=1`, so a SQL error (e.g. a fixture query
+/// that panics in the engine) makes psql exit non-zero with empty
+/// stdout. If the caller ignored that, an erroring *zero-result*
+/// fixture would produce empty output that matches an empty golden and
+/// pass silently — defeating the harness. The caller treats a non-zero
+/// exit as a hard fixture failure.
+fn engine(engine_cmd: &str, sql: &str) -> Result<(String, bool), String> {
     let mut child = Command::new("sh")
         .arg("-c")
         .arg(engine_cmd)
@@ -261,7 +273,10 @@ fn engine(engine_cmd: &str, sql: &str) -> Result<String, String> {
     let out = child
         .wait_with_output()
         .map_err(|e| format!("engine wait: {e}"))?;
-    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    Ok((
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.success(),
+    ))
 }
 
 /// Normalize raw engine output into canonical golden lines: keep only
@@ -278,23 +293,30 @@ fn normalize(raw: &str) -> Vec<String> {
     lines
 }
 
-/// Textual `"elapsed_ms": <number>` → `"elapsed_ms": 0`. Textual on
+/// Textual `"elapsed_ms": <number>` → `"elapsed_ms": 0`, for EVERY
+/// occurrence on the line (the removed bash normalizer used a global
+/// `sed s/.../g`; a single-occurrence replace would leave a second
+/// timing value in the row and flap the golden run-to-run). Textual on
 /// purpose: goldens are byte-compared against psql's jsonb rendering,
 /// so a parse → re-serialize round-trip would perturb formatting.
 fn zero_elapsed_ms(line: &str) -> String {
     const KEY: &str = "\"elapsed_ms\": ";
-    let Some(start) = line.find(KEY) else {
-        return line.to_string();
-    };
-    let num_start = start + KEY.len();
-    let rest = &line[num_start..];
-    let num_len = rest
-        .find(|c: char| !(c.is_ascii_digit() || "eE.+-".contains(c)))
-        .unwrap_or(rest.len());
-    if num_len == 0 {
-        return line.to_string();
+    let mut parts = line.split(KEY);
+    let mut out = String::from(parts.next().unwrap_or(""));
+    for seg in parts {
+        out.push_str(KEY);
+        // `seg` begins with the number that followed this KEY.
+        let num_len = seg
+            .find(|c: char| !(c.is_ascii_digit() || "eE.+-".contains(c)))
+            .unwrap_or(seg.len());
+        if num_len == 0 {
+            out.push_str(seg); // KEY not followed by a number — leave as-is
+        } else {
+            out.push('0');
+            out.push_str(&seg[num_len..]);
+        }
     }
-    format!("{}0{}", &line[..num_start], &rest[num_len..])
+    out
 }
 
 fn read_lines(path: &Path) -> Result<Vec<String>, String> {
@@ -437,6 +459,15 @@ mod tests {
         // SELECT rows untouched.
         let row = r#"{"s": "x", "n": "elapsed_ms is data here"}"#;
         assert_eq!(zero_elapsed_ms(row), row);
+        // EVERY occurrence is zeroed (global, matching the old sed -g),
+        // not just the first.
+        assert_eq!(
+            zero_elapsed_ms(r#"{"elapsed_ms": 7, "b": 1, "elapsed_ms": 42}"#),
+            r#"{"elapsed_ms": 0, "b": 1, "elapsed_ms": 0}"#
+        );
+        // Key with no following number is left intact.
+        let no_num = r#"{"elapsed_ms": "x"}"#;
+        assert_eq!(zero_elapsed_ms(no_num), no_num);
     }
 
     #[test]

--- a/tests/regression/expected/100-construct-foundation.out
+++ b/tests/regression/expected/100-construct-foundation.out
@@ -3,7 +3,7 @@
 4
 1
 iri|http://example.com/t1|iri|http://example.com/t2|literal|x|http://www.w3.org/2001/XMLSchema#string
-3
+1
 1
 literal|42|http://www.w3.org/2001/XMLSchema#integer
 0

--- a/tests/regression/sql/100-construct-foundation.sql
+++ b/tests/regression/sql/100-construct-foundation.sql
@@ -21,9 +21,11 @@
 --
 --   A. Constant-only template, single solution — one row carrying
 --      the constant template, structured shape verified.
---   B. Constant-only template, N solutions — N identical rows (one
---      per solution per W3C 1.1 §16.2's "solution sequence is the
---      BGP's; multiplicity matters").
+--   B. Constant-only template, N solutions — ONE triple (#54). A
+--      CONSTRUCT result is an RDF graph (a set), so N identical
+--      triples from N solutions collapse to one; the solution
+--      sequence's multiplicity does not survive into the graph
+--      (W3C 1.1 §16.2).
 --   C. Multi-position constant types — IRI subject, IRI predicate,
 --      typed-literal object (xsd:integer). Datatype IRI surfaces
 --      verbatim in the term cell.
@@ -101,15 +103,18 @@ FROM pgrdf.construct(
   'WHERE { <http://example.com/s> <http://example.com/p> <http://example.com/o> }'
 ) AS s(j);
 
--- ─── Invariant B: constant template, three solutions, three rows ─
+-- ─── Invariant B: constant template, three solutions → ONE triple ─
+-- §16.2 set semantics (#54): the WHERE matches three solutions, but
+-- the constant template yields the SAME triple each time, so the
+-- output graph holds it once. b_row_count is 1, not 3.
 SELECT count(*)::bigint AS b_row_count
   FROM pgrdf.construct(
     'CONSTRUCT { <http://example.com/tag> <http://example.com/k> "v" } '
     'WHERE { ?s <http://example.com/k> ?o }'
   ) AS s(j);
 
--- All three rows must carry the same constant template payload —
--- verify by counting distinct row shapes.
+-- The single surviving row carries the constant template payload —
+-- b_distinct_rows equals b_row_count (both 1) after set dedup.
 SELECT count(DISTINCT j)::bigint AS b_distinct_rows
   FROM pgrdf.construct(
     'CONSTRUCT { <http://example.com/tag> <http://example.com/k> "v" } '

--- a/tests/w3c-sparql/32-construct-constant-template/expected.jsonl
+++ b/tests/w3c-sparql/32-construct-constant-template/expected.jsonl
@@ -1,3 +1,1 @@
 {"object": {"type": "literal", "value": "loaded", "datatype": "http://www.w3.org/2001/XMLSchema#string"}, "subject": {"type": "iri", "value": "http://example.org/dataset"}, "predicate": {"type": "iri", "value": "http://example.org/hasState"}}
-{"object": {"type": "literal", "value": "loaded", "datatype": "http://www.w3.org/2001/XMLSchema#string"}, "subject": {"type": "iri", "value": "http://example.org/dataset"}, "predicate": {"type": "iri", "value": "http://example.org/hasState"}}
-{"object": {"type": "literal", "value": "loaded", "datatype": "http://www.w3.org/2001/XMLSchema#string"}, "subject": {"type": "iri", "value": "http://example.org/dataset"}, "predicate": {"type": "iri", "value": "http://example.org/hasState"}}

--- a/tests/w3c-sparql/32-construct-constant-template/oracle
+++ b/tests/w3c-sparql/32-construct-constant-template/oracle
@@ -1,1 +1,1 @@
-known-divergence: #54 — CONSTRUCT emits one row per solution×template pair; W3C §16.2 defines the result as a graph (set semantics)
+eligible


### PR DESCRIPTION
## What

Closes #54, and folds in the **pre-v0.6.19 code-review hardening** (the review found genuine bugs before the tag — exactly what a pre-release review is for).

### #54 — CONSTRUCT result is a set
CONSTRUCT emitted one row per (solution × template-triple), so a template producing the same triple across N solutions returned it N times. W3C §16.2 defines the result as an RDF **graph** — a set. Row-level dedup at the return (`dedup_construct_rows`); minted template blank nodes get a fresh label per solution (§16.2.1) so their rows correctly survive, only byte-identical ground triples collapse. The #17 oracle caught this on its first run (fixture 32 flipped `known-divergence` → `eligible`, now matches spareval).

### Review hardening (findings, all verified fixed)
**`src/query/executor.rs` (expression surface):**
- **[2] `math:pow` overflow → SQL abort.** `power(1e200, 2)` aborted the whole query, violating the tier's "never a SQL abort" contract. Added the overflow guard (`y·ln|x| > 709.78 → UNBOUND`) alongside the existing domain guards.
- **[1] `INF`/`-INF`/`NaN` xsd:double literal → SQL abort.** These lowered to unquoted `INF::numeric` (a column reference → abort on a *valid* SPARQL literal). Now mapped to Postgres' quoted `'Infinity'`/`'-Infinity'`/`'NaN'` numeric special-values; finite values unchanged. (Pre-existing bug, surfaced by the review.)
- **[8] `math:exp` guard too tight.** `exp(709.5)` is a representable double but returned unbound; guard widened `709 → 709.78` (ln(f64::MAX)).
- **[9]** `dedup_construct_rows` skips the serialize+hash pass for ≤1 row.

**`tests/oracle/` (differential harness):**
- **[5] engine exit status ignored.** An erroring *zero-result* fixture matched an empty golden and read green — defeating the harness. `engine()` now returns the psql exit status; a non-zero exit (SQL error under `ON_ERROR_STOP=1`) is a hard fixture FAIL.
- **[6] `zero_elapsed_ms` first-only.** Restored global replace (the bash normalizer used `sed -g`).

### Kept by design (not bugs)
Findings [3] (property-path truncation WARNs by default) and [4] (carve boundary NOTICE) are the #14 fail-closed **visibility** behavior — intentional, documented in the CHANGELOG.

### Deferred with tracking
Finding [7] (oracle `numeric_eq` blinds "2" vs "2.0") → **#62** (v0.6.20 soundness tightening). The oracle is net-positive as-is (it caught #54 and #55).

## Verification (isolated container, this branch's `.so`)

| gate | result |
|---|---|
| pgrx suite | **339/339** (3 new math tests + the #54 pair) |
| regression | 100/100 |
| W3C + differential oracle | 53/53 · 38 oracle-match · 1 known-divergence (#55, documented) · 0 diverge |
| oracle crate | 35 (30 unit + 5 CLI) |
| fmt + clippy `-D warnings` | clean |

CHANGELOG deliberately untouched — folds into the v0.6.19 release cut (#60), where the `[0.6.19]` entry gains the #54 + hardening lines.
