### PR TITLE
test(shacl): generate the SHACL capability document (#79)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@ fixtures/regression/*.nt
 
 # Superpowers working artifacts (specs/plans) — local only
 docs/superpowers/
+
+# CKP v3.11 wave working documents — internal, never committed to this public repo.
+# Covers CKP.*.VISION-REQUIREMENTS-STATEMENT.md and any SPEC.* drafts dropped here.
+CK*.md
+SPEC*.md
+# ...but pgRDF's OWN published engineering specs are tracked, public, and unrelated to CKP.
+!specs/SPEC.pgRDF.*.md

--- a/tests/shacl-capability/CAPABILITY.json
+++ b/tests/shacl-capability/CAPABILITY.json
@@ -1,0 +1,136 @@
+{
+  "artifact": "pgrdf-shacl-capability",
+  "caveats": [
+    "validate does NOT entail: sh:targetClass matches ASSERTED rdf:type only. A node typed only by a subclass is not targeted by a shape on its parent unless pgrdf.materialize has run, or the parent type is stamped explicitly.",
+    "A constraint component absent from `enforced` contributes no violation and no error. conforms:true therefore does not distinguish 'validated clean' from 'never evaluated'. See pgRDF#80."
+  ],
+  "enforced": [
+    "class",
+    "closed",
+    "datatype",
+    "disjoint",
+    "hasValue",
+    "in",
+    "inversePath",
+    "maxCount",
+    "minCount",
+    "minLength",
+    "nodeKind",
+    "pattern",
+    "qualifiedMinCount",
+    "targetClass",
+    "targetNode",
+    "targetSubjectsOf"
+  ],
+  "generated_by": "tests/shacl-capability/run.sh",
+  "hand_edited": false,
+  "not_enforced": [
+    "sparqlConstraint"
+  ],
+  "pgrdf_version": "0.6.22",
+  "postgres_major": 18,
+  "probes": [
+    {
+      "component": "class",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "closed",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "datatype",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "disjoint",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "hasValue",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "in",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "inversePath",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "maxCount",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "minCount",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "minLength",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "nodeKind",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "pattern",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "qualifiedMinCount",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "sparqlConstraint",
+      "control_conforms": true,
+      "verdict": "SILENTLY-SKIPPED",
+      "violating_conforms": true
+    },
+    {
+      "component": "targetClass",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "targetNode",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    },
+    {
+      "component": "targetSubjectsOf",
+      "control_conforms": true,
+      "verdict": "enforced",
+      "violating_conforms": false
+    }
+  ]
+}

--- a/tests/shacl-capability/README.md
+++ b/tests/shacl-capability/README.md
@@ -1,0 +1,56 @@
+# tests/shacl-capability — the SHACL capability document
+
+Generates [`CAPABILITY.json`](CAPABILITY.json): for each SHACL constraint
+component and target selector, **does `pgrdf.validate` actually enforce it
+on this build?**
+
+## Why
+
+Consumers choose shapes against what the engine enforces, not against what
+the SHACL specification defines. Those two sets are not the same, and the
+difference is invisible: an unimplemented component contributes no violation
+**and no error**, so `conforms:true` does not distinguish *validated clean*
+from *never evaluated*.
+
+Before this harness the allowlist lived in prose. A shape chosen against
+prose is a shape chosen against a guess.
+
+## Method
+
+Each probe is three checked-in `.ttl` files — hermetic, no fetch at test time:
+
+    <component>.shapes.ttl      the shapes graph
+    <component>.violating.ttl   data breaking exactly that component
+    <component>.control.ttl     data satisfying it
+
+Shapes and data load into **separate** graphs, because that is how a caller
+validates, and because a self-validating graph makes the shape node its own
+typed subject — which silently breaks any probe using `sh:targetSubjectsOf`.
+
+A component is **enforced** only when `violating => conforms:false` **and**
+`control => conforms:true`. The control rules out an engine that reports
+`false` for everything; the violating case rules out a silent skip.
+
+## Running
+
+    ./run.sh            # regenerate CAPABILITY.json
+    ./run.sh --print    # table only, no file write
+
+Uses standard `PG*` environment variables. Creates and drops its own scratch
+graphs; it writes nothing else and is safe against a shared database.
+
+**`CAPABILITY.json` is generated. Never hand-edit it.** Regenerate after any
+change to the `shacl` crate pin, the validator, or the PG major.
+
+## Reading the output
+
+`not_enforced` is the load-bearing field. A component listed there is one a
+shapes graph may reference and receive no enforcement for, with no diagnostic.
+
+The `caveats` array carries two facts no probe table can express:
+
+1. **Validation does not entail.** `sh:targetClass` matches *asserted*
+   `rdf:type` only. A node typed solely by a subclass is not targeted by a
+   shape on its parent unless `pgrdf.materialize` has run or the parent type
+   was stamped explicitly.
+2. **Absence is silent.** See the `not_enforced` note above, and pgRDF#80.

--- a/tests/shacl-capability/fixtures/class.control.ttl
+++ b/tests/shacl-capability/fixtures/class.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p ex:b . ex:b a ex:Thing .

--- a/tests/shacl-capability/fixtures/class.shapes.ttl
+++ b/tests/shacl-capability/fixtures/class.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:class ex:Thing ] .

--- a/tests/shacl-capability/fixtures/class.violating.ttl
+++ b/tests/shacl-capability/fixtures/class.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p ex:b . ex:b a ex:Other .

--- a/tests/shacl-capability/fixtures/closed.control.ttl
+++ b/tests/shacl-capability/fixtures/closed.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "ok" .

--- a/tests/shacl-capability/fixtures/closed.shapes.ttl
+++ b/tests/shacl-capability/fixtures/closed.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:closed true ; sh:ignoredProperties ( rdf:type ) ; sh:property [ sh:path ex:p ] .

--- a/tests/shacl-capability/fixtures/closed.violating.ttl
+++ b/tests/shacl-capability/fixtures/closed.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "ok" ; ex:undeclared "extra" .

--- a/tests/shacl-capability/fixtures/datatype.control.ttl
+++ b/tests/shacl-capability/fixtures/datatype.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p 7 .

--- a/tests/shacl-capability/fixtures/datatype.shapes.ttl
+++ b/tests/shacl-capability/fixtures/datatype.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:datatype xsd:integer ] .

--- a/tests/shacl-capability/fixtures/datatype.violating.ttl
+++ b/tests/shacl-capability/fixtures/datatype.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "abc" .

--- a/tests/shacl-capability/fixtures/disjoint.control.ttl
+++ b/tests/shacl-capability/fixtures/disjoint.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "one" ; ex:q "two" .

--- a/tests/shacl-capability/fixtures/disjoint.shapes.ttl
+++ b/tests/shacl-capability/fixtures/disjoint.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:disjoint ex:q ] .

--- a/tests/shacl-capability/fixtures/disjoint.violating.ttl
+++ b/tests/shacl-capability/fixtures/disjoint.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "same" ; ex:q "same" .

--- a/tests/shacl-capability/fixtures/hasValue.control.ttl
+++ b/tests/shacl-capability/fixtures/hasValue.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "readwrite" .

--- a/tests/shacl-capability/fixtures/hasValue.shapes.ttl
+++ b/tests/shacl-capability/fixtures/hasValue.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:hasValue "readwrite" ] .

--- a/tests/shacl-capability/fixtures/hasValue.violating.ttl
+++ b/tests/shacl-capability/fixtures/hasValue.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "readonly" .

--- a/tests/shacl-capability/fixtures/in.control.ttl
+++ b/tests/shacl-capability/fixtures/in.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "ck" .

--- a/tests/shacl-capability/fixtures/in.shapes.ttl
+++ b/tests/shacl-capability/fixtures/in.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:in ( "ck" "tool" "data" ) ] .

--- a/tests/shacl-capability/fixtures/in.violating.ttl
+++ b/tests/shacl-capability/fixtures/in.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "banana" .

--- a/tests/shacl-capability/fixtures/inversePath.control.ttl
+++ b/tests/shacl-capability/fixtures/inversePath.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:k ex:hasOrgan ex:o . ex:o a ex:Organ .

--- a/tests/shacl-capability/fixtures/inversePath.shapes.ttl
+++ b/tests/shacl-capability/fixtures/inversePath.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:Organ ; sh:property [ sh:path [ sh:inversePath ex:hasOrgan ] ; sh:minCount 1 ] .

--- a/tests/shacl-capability/fixtures/inversePath.violating.ttl
+++ b/tests/shacl-capability/fixtures/inversePath.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:o a ex:Organ .

--- a/tests/shacl-capability/fixtures/maxCount.control.ttl
+++ b/tests/shacl-capability/fixtures/maxCount.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "one" .

--- a/tests/shacl-capability/fixtures/maxCount.shapes.ttl
+++ b/tests/shacl-capability/fixtures/maxCount.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:maxCount 1 ] .

--- a/tests/shacl-capability/fixtures/maxCount.violating.ttl
+++ b/tests/shacl-capability/fixtures/maxCount.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "one" ; ex:p "two" .

--- a/tests/shacl-capability/fixtures/minCount.control.ttl
+++ b/tests/shacl-capability/fixtures/minCount.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "v" .

--- a/tests/shacl-capability/fixtures/minCount.shapes.ttl
+++ b/tests/shacl-capability/fixtures/minCount.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:minCount 1 ] .

--- a/tests/shacl-capability/fixtures/minCount.violating.ttl
+++ b/tests/shacl-capability/fixtures/minCount.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T .

--- a/tests/shacl-capability/fixtures/minLength.control.ttl
+++ b/tests/shacl-capability/fixtures/minLength.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "beef" .

--- a/tests/shacl-capability/fixtures/minLength.shapes.ttl
+++ b/tests/shacl-capability/fixtures/minLength.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:minLength 4 ] .

--- a/tests/shacl-capability/fixtures/minLength.violating.ttl
+++ b/tests/shacl-capability/fixtures/minLength.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "" .

--- a/tests/shacl-capability/fixtures/nodeKind.control.ttl
+++ b/tests/shacl-capability/fixtures/nodeKind.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p ex:b .

--- a/tests/shacl-capability/fixtures/nodeKind.shapes.ttl
+++ b/tests/shacl-capability/fixtures/nodeKind.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:nodeKind sh:IRI ] .

--- a/tests/shacl-capability/fixtures/nodeKind.violating.ttl
+++ b/tests/shacl-capability/fixtures/nodeKind.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "literal" .

--- a/tests/shacl-capability/fixtures/pattern.control.ttl
+++ b/tests/shacl-capability/fixtures/pattern.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "beef" .

--- a/tests/shacl-capability/fixtures/pattern.shapes.ttl
+++ b/tests/shacl-capability/fixtures/pattern.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:pattern "^[0-9a-f]{4}$" ] .

--- a/tests/shacl-capability/fixtures/pattern.violating.ttl
+++ b/tests/shacl-capability/fixtures/pattern.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "x" .

--- a/tests/shacl-capability/fixtures/qualifiedMinCount.control.ttl
+++ b/tests/shacl-capability/fixtures/qualifiedMinCount.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:k a ex:K ; ex:organ ex:o1 . ex:o1 ex:kind "ck" .

--- a/tests/shacl-capability/fixtures/qualifiedMinCount.shapes.ttl
+++ b/tests/shacl-capability/fixtures/qualifiedMinCount.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:K ; sh:property [ sh:path ex:organ ; sh:qualifiedValueShape [ sh:property [ sh:path ex:kind ; sh:hasValue "ck" ] ] ; sh:qualifiedMinCount 1 ] .

--- a/tests/shacl-capability/fixtures/qualifiedMinCount.violating.ttl
+++ b/tests/shacl-capability/fixtures/qualifiedMinCount.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:k a ex:K ; ex:organ ex:o1 . ex:o1 ex:kind "data" .

--- a/tests/shacl-capability/fixtures/sparqlConstraint.control.ttl
+++ b/tests/shacl-capability/fixtures/sparqlConstraint.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p 5 .

--- a/tests/shacl-capability/fixtures/sparqlConstraint.shapes.ttl
+++ b/tests/shacl-capability/fixtures/sparqlConstraint.shapes.ttl
@@ -1,0 +1,7 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ;
+  sh:sparql [ a sh:SPARQLConstraint ; sh:message "p must not exceed 10" ;
+              sh:select "SELECT $this WHERE { $this <http://ex/p> ?v . FILTER(?v > 10) }" ] .

--- a/tests/shacl-capability/fixtures/sparqlConstraint.violating.ttl
+++ b/tests/shacl-capability/fixtures/sparqlConstraint.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p 20 .

--- a/tests/shacl-capability/fixtures/targetClass.control.ttl
+++ b/tests/shacl-capability/fixtures/targetClass.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T ; ex:p "x" .

--- a/tests/shacl-capability/fixtures/targetClass.shapes.ttl
+++ b/tests/shacl-capability/fixtures/targetClass.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetClass ex:T ; sh:property [ sh:path ex:p ; sh:minCount 1 ] .

--- a/tests/shacl-capability/fixtures/targetClass.violating.ttl
+++ b/tests/shacl-capability/fixtures/targetClass.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:T .

--- a/tests/shacl-capability/fixtures/targetNode.control.ttl
+++ b/tests/shacl-capability/fixtures/targetNode.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a ex:p "x" .

--- a/tests/shacl-capability/fixtures/targetNode.shapes.ttl
+++ b/tests/shacl-capability/fixtures/targetNode.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetNode ex:a ; sh:property [ sh:path ex:p ; sh:minCount 1 ] .

--- a/tests/shacl-capability/fixtures/targetNode.violating.ttl
+++ b/tests/shacl-capability/fixtures/targetNode.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a ex:other "x" .

--- a/tests/shacl-capability/fixtures/targetSubjectsOf.control.ttl
+++ b/tests/shacl-capability/fixtures/targetSubjectsOf.control.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:Admitted .

--- a/tests/shacl-capability/fixtures/targetSubjectsOf.shapes.ttl
+++ b/tests/shacl-capability/fixtures/targetSubjectsOf.shapes.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:S a sh:NodeShape ; sh:targetSubjectsOf rdf:type ; sh:property [ sh:path rdf:type ; sh:in ( ex:Admitted ) ] .

--- a/tests/shacl-capability/fixtures/targetSubjectsOf.violating.ttl
+++ b/tests/shacl-capability/fixtures/targetSubjectsOf.violating.ttl
@@ -1,0 +1,5 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+ex:a a ex:NotAdmitted .

--- a/tests/shacl-capability/run.sh
+++ b/tests/shacl-capability/run.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# tests/shacl-capability/run.sh — generate the SHACL capability document.
+#
+# Answers ONE question, per constraint component and target selector:
+#   does `pgrdf.validate` actually ENFORCE it, on THIS build?
+#
+# Method mirrors tests/w3c-shacl/run.sh in spirit — hermetic,
+# checked-in `.ttl` fixtures, no fetch at test time. Each probe ships
+# as a TRIPLE:
+#
+#   <component>.shapes.ttl     — the shapes graph
+#   <component>.violating.ttl  — data that breaks exactly that component
+#   <component>.control.ttl    — data that satisfies it
+#
+# Shapes and data go into SEPARATE graphs, because that is how the seal
+# calls the validator — and because a self-validating graph makes the
+# shape node its own typed subject, which silently breaks any probe
+# using `sh:targetSubjectsOf`.
+#
+# A component is ENFORCED only when violating => conforms:false AND
+# control => conforms:true. The control is what distinguishes a working
+# constraint from an engine that reports false for everything; the
+# violating case is what distinguishes it from one that silently skips.
+#
+# Output is `CAPABILITY.json`, written next to this script. It is
+# GENERATED — never hand-edited. Regenerate after any change to the
+# shacl crate pin, the validator, or the PG major.
+#
+# Why this exists: CKP RULE-13 binds the core ontology to "constraints
+# this engine enforces", not "constraints SHACL Core defines". Before
+# this harness, that allowlist lived in prose, and a shape chosen
+# against prose is a shape chosen against a guess.
+#
+# Usage:  ./run.sh                 (uses PG* env, or the defaults below)
+#         PGHOST=… PGPORT=… ./run.sh
+#         ./run.sh --print         (human-readable table, no file write)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIX="${HERE}/fixtures"
+OUT="${HERE}/CAPABILITY.json"
+PRINT_ONLY=0
+[[ "${1:-}" == "--print" ]] && PRINT_ONLY=1
+
+psql_q() { psql -v ON_ERROR_STOP=1 -tAq -c "$1"; }
+
+# Load one probe into scratch shapes + data graphs, validate, return
+# the `conforms` value. Both graphs are dropped immediately, so this
+# harness is safe against a shared database (bench class B1).
+probe() {
+  local comp="$1"
+  local kind="$2"
+  local mode="$3"
+  local sg="urn:pgrdf-capability:${comp}:${kind}:${mode}:shapes"
+  local dg="urn:pgrdf-capability:${comp}:${kind}:${mode}:data"
+  local shapes; shapes="$(cat "${FIX}/${comp}.shapes.ttl")"
+  local data;   data="$(cat "${FIX}/${comp}.${kind}.ttl")"
+  psql_q "$(cat <<SQL
+DO \$probe\$
+DECLARE sg bigint; dg bigint; rep jsonb;
+BEGIN
+  BEGIN PERFORM pgrdf.drop_graph('${sg}'); PERFORM pgrdf.drop_graph('${dg}'); EXCEPTION WHEN OTHERS THEN NULL; END;
+  sg := pgrdf.add_graph('${sg}');
+  dg := pgrdf.add_graph('${dg}');
+  PERFORM pgrdf.parse_turtle(\$s\$${shapes}\$s\$, sg);
+  PERFORM pgrdf.parse_turtle(\$d\$${data}\$d\$, dg);
+  rep := pgrdf.validate(dg, sg, '${mode}');
+  PERFORM pgrdf.drop_graph('${sg}'); PERFORM pgrdf.drop_graph('${dg}');
+  RAISE NOTICE 'PROBE=%', coalesce(rep->>'conforms','null');
+END \$probe\$;
+SQL
+)" 2>&1 | sed -n 's/^NOTICE:  PROBE=//p'
+}
+
+PG_VER="$(psql_q 'SHOW server_version;' | cut -d. -f1)"
+PGRDF_VER="$(psql_q 'SELECT pgrdf.version();')"
+
+components=()
+for v in "${FIX}"/*.shapes.ttl; do
+  components+=( "$(basename "$v" .shapes.ttl)" )
+done
+
+rows=""; enforced=(); not_enforced=()
+for c in "${components[@]}"; do
+  bad="$(probe "$c" violating native)"
+  good="$(probe "$c" control native)"
+  if [[ "$bad" == "false" && "$good" == "true" ]]; then
+    verdict="enforced";      enforced+=( "$c" )
+  elif [[ "$bad" == "true" ]]; then
+    verdict="SILENTLY-SKIPPED"; not_enforced+=( "$c" )
+  else
+    verdict="INDETERMINATE";    not_enforced+=( "$c" )
+  fi
+  printf '  %-22s violating=%-5s control=%-5s  %s\n' "$c" "$bad" "$good" "$verdict"
+  rows+="$(printf '{"component":"%s","violating_conforms":%s,"control_conforms":%s,"verdict":"%s"}' \
+            "$c" "${bad:-null}" "${good:-null}" "$verdict"),"
+done
+
+(( PRINT_ONLY )) && exit 0
+
+python3 - "$OUT" "$PGRDF_VER" "$PG_VER" "${rows%,}" <<'PY'
+import json, sys
+out, pgrdf, pg, rows = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+probes = json.loads("["+rows+"]")
+doc = {
+  "artifact": "pgrdf-shacl-capability",
+  "generated_by": "tests/shacl-capability/run.sh",
+  "hand_edited": False,
+  "pgrdf_version": pgrdf,
+  "postgres_major": int(pg),
+  "enforced": sorted(p["component"] for p in probes if p["verdict"] == "enforced"),
+  "not_enforced": sorted(p["component"] for p in probes if p["verdict"] != "enforced"),
+  "probes": probes,
+  "caveats": [
+    "validate does NOT entail: sh:targetClass matches ASSERTED rdf:type only. "
+    "A node typed only by a subclass is not targeted by a shape on its parent "
+    "unless pgrdf.materialize has run, or the parent type is stamped explicitly.",
+    "A constraint component absent from `enforced` contributes no violation and "
+    "no error. conforms:true therefore does not distinguish 'validated clean' "
+    "from 'never evaluated'. See pgRDF#80.",
+  ],
+}
+with open(out, "w") as f:
+    json.dump(doc, f, indent=2, sort_keys=True); f.write("\n")
+print(f"\nwrote {out}: {len(doc['enforced'])} enforced, {len(doc['not_enforced'])} not enforced")
+PY


### PR DESCRIPTION
Closes #79.

Adds `tests/shacl-capability` — a hermetic harness that measures, per SHACL
constraint component and target selector, whether `pgrdf.validate` actually
enforces it **on this build** — and emits `CAPABILITY.json`.

Generated, not hand-written, per the ask on #79.

## Result on 0.6.22 / PG18 — 16 enforced, 1 not

`class` · `closed` · `datatype` · `disjoint` · `hasValue` · `in` ·
`inversePath` · `maxCount` · `minCount` · `minLength` · `nodeKind` ·
`pattern` · `qualifiedMinCount` · `targetClass` · `targetNode` ·
`targetSubjectsOf`

## The finding: `sh:sparql` is silently skipped

A `sh:SPARQLConstraint` whose `sh:select` identifies a violating focus node
returns **`conforms:true`, zero results, no `error`** — in **both** `native`
and `sparql` mode.

This is a regression in *diagnosability*, not in capability. The mode now
dispatches (the ERRATA E-012 short-circuit guard was removed with the
`shacl 0.3.2` bump), but the constraint component itself is still not
evaluated. Previously a caller relying on SHACL-SPARQL received
`conforms:null` plus an explicit `error` naming the gap — unusable, but
honest. They now receive a clean pass, indistinguishable from validated.

That is exactly the defect #80 exists to fix, and it is live in the shipped
release.

## Method note

Shapes and data load into **separate** graphs. That is how a caller
validates, and a self-validating graph makes the shape node its own typed
subject — which silently broke the `sh:targetSubjectsOf` probe on the first
run and reported it INDETERMINATE.

## Verification

    cd tests/shacl-capability && ./run.sh --print

Creates and drops its own scratch graphs; writes nothing else.

Also carries the `.gitignore` `CK*.md` / `SPEC*.md` patterns with a
`!specs/SPEC.pgRDF.*.md` exception, so pgRDF s own published engineering
specs stay tracked.