### PR TITLE
fix(shmem): invalidate the dict cache at CREATE EXTENSION (#88)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,5 +148,11 @@ pub mod pg_test {
 extension_sql!(
     r#"SELECT pgrdf.shmem_reset();"#,
     name = "dict_cache_generation_bump_on_install",
-    requires = [crate::storage::stats::shmem_reset],
+    // NOTE the missing `crate::` — pgrx matches a `requires` FullPath by
+    // `module_path.ends_with(path-without-last-segment)`, and the extern's
+    // module_path is `pgrdf::storage::stats`. With `crate::` the suffix match
+    // fails SILENTLY: no ordering is enforced, the SELECT is emitted before
+    // the function exists, and CREATE EXTENSION dies. The caveat is documented
+    // twelve lines above this one and I still wrote it wrong.
+    requires = [storage::stats::shmem_reset],
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,3 +124,29 @@ pub mod pg_test {
         vec!["shared_preload_libraries='pgrdf'"]
     }
 }
+
+// #88 — invalidate the shmem dictionary cache at CREATE EXTENSION.
+//
+// The cache keys a term fingerprint to a dictionary id and guards each
+// slot with a GENERATION counter, so a stale slot reads as cold. That
+// guard was correct and it was only ever advanced by an explicit
+// `pgrdf.shmem_reset()` — a manual step `reset()`'s own doc comment
+// asked users to remember after `DROP EXTENSION`.
+//
+// Nothing remembers. On a server with pgrdf preloaded, DROP EXTENSION
+// followed by CREATE EXTENSION recreates `_pgrdf_dictionary` empty and
+// restarts ids at 1, while every cached fingerprint still carries the
+// CURRENT generation. Each one now resolves to whatever term happens to
+// hold that id in the new dictionary, and it does so silently:
+// `ex:s a ex:T` was measured storing predicate `rdfs:label`, because
+// rdf:type's id in the previous extension lifetime is rdfs:label's id
+// in this one.
+//
+// A correctness invariant must not depend on a human running a
+// function. Bumping the generation here makes a fresh extension
+// unable to inherit a stale cache, by construction.
+extension_sql!(
+    r#"SELECT pgrdf.shmem_reset();"#,
+    name = "dict_cache_generation_bump_on_install",
+    requires = [crate::storage::stats::shmem_reset],
+);


### PR DESCRIPTION
Closes #88. **Silent cross-lifetime data corruption.**

## Symptom

`rdf:type` is **stored** as `rdfs:label`:

```
parse_turtle(%27ex:s a ex:T .%27)  ->  <http://ex/s> <rdfs:label> <http://ex/T>
```

CK-org found it and correctly ruled out `base_iri`, the `rdf:` prefix, `materialize`
and query-side projection — and could not find why it fires on some graphs and not
others.

## It is not the dictionary

`rdf:type` = id 18, `rdfs:label` = id 4, and both `lexical_md5` values match
independently computed MD5s. No collision. **The wrong `predicate_id` was written.**

## Cause — the generation guard was never advanced automatically

| | predicate stored |
|---|---|
| no reset | `rdfs:label` ❌ |
| after `pgrdf.shmem_reset()` | `rdf:type` ✅ |

The shmem cache keys a term fingerprint to a dictionary id and guards each slot with
a `GENERATION` counter so a stale slot reads as cold. **That guard is correct.** It
was advanced in exactly one place — an explicit `pgrdf.shmem_reset()` — which
`reset()`%27s own doc comment asks users to run *"after `DROP EXTENSION pgrdf` so the
new extension%27s dict id space doesn%27t collide with the stale cache."*

**Nothing remembers.** On a server with `pgrdf` preloaded, `DROP EXTENSION` then
`CREATE EXTENSION` recreates `_pgrdf_dictionary` empty and restarts ids at 1, while
every cached fingerprint still carries the **current** generation. Each one resolves
to whatever term now holds that id. `rdf:type`%27s id in the previous lifetime is
`rdfs:label`%27s id in this one.

**That is also why the discriminating factor was not findable in the graph: it is
history, not content.**

## Fix

`CREATE EXTENSION` bumps the generation. A fresh extension cannot inherit a stale
cache by construction.

**A correctness invariant must not depend on a human running a function.** The guard
was designed for exactly this hazard and its activation was left as a convention.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo check`
all clean on pg18.

## Note for reviewers

The regression suite does `DROP EXTENSION … CASCADE; CREATE EXTENSION pgrdf;` in
several fixtures, which is precisely the sequence that arms this. Any fixture that
passed while the cache was poisoned was passing by luck.