### PR TITLE
feat(build-id): report which build is loaded; bare module_pathname (#92)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,12 @@
+//! Build script — build identity only.
+//!
+//! `PGRDF_BUILD_ID` is read with `option_env!` in `src/lib.rs`, which is a
+//! COMPILE-TIME lookup. Without the line below, cargo has no reason to
+//! recompile when the variable changes, so a rebuild would silently keep the
+//! previous build id. That is worse than having none: it would report a build
+//! that is not the one loaded, which is the exact failure this function exists
+//! to prevent.
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=PGRDF_BUILD_ID");
+}

--- a/compose/rust-builder-entrypoint.sh
+++ b/compose/rust-builder-entrypoint.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# ck-build — SPEC.RUST-BUILDER.CK.v3.11 §3/§5/§7.
+#
+# Reads a pgrx crate from a read-only /src mount, resolves cargo-pgrx
+# from that crate's OWN pin, packages it, and writes the artifact set
+# atomically to /out.
+#
+#   /src     repo, read-only
+#   /out     delivery target (the pgck-localhost ext volume)
+#   /target  per-repo cargo target dir (writable; /src is ro)
+#   /pgrx    version-scoped cargo-pgrx installs + PGRX_HOME (shared cache)
+set -euo pipefail
+
+# package (default) -> build and deliver to /out
+# test              -> run the pgrx test suite, deliver nothing
+#
+# `test` exists so the suite runs through the SAME toolchain that produces the
+# artifact. Running it by hand with `--entrypoint bash` silently omits the
+# version-scoped cargo-pgrx from PATH; the pgrx harness then fails at its
+# internal `cargo pgrx install` and reports it as ~300 failing tests, which
+# reads like a broken change rather than a missing PATH.
+MODE="${1:-package}"
+PG_MAJOR="${PG_MAJOR:-18}"
+SRC=/src
+OUT=/out
+say() { printf '  %-22s %s\n' "$1" "$2"; }
+die() { printf '\n!! %s\n' "$*" >&2; exit 1; }
+
+echo "ck-build · SPEC.RUST-BUILDER.CK.v3.11"
+[ -f "$SRC/Cargo.toml" ] || die "no Cargo.toml at $SRC — mount the repo read-only at /src"
+
+# ---- identity -------------------------------------------------------------
+EXT=$(sed -n '/^\[package\]/,/^\[/p' "$SRC/Cargo.toml" | sed -n 's/^name *= *"\(.*\)"/\1/p' | head -1)
+VER=$(sed -n '/^\[package\]/,/^\[/p' "$SRC/Cargo.toml" | sed -n 's/^version *= *"\(.*\)"/\1/p' | head -1)
+[ -n "$EXT" ] || die "could not read package name from $SRC/Cargo.toml"
+
+# Git identity is what makes the artifact attributable. A dirty tree
+# means the .so corresponds to no commit anyone else can fetch.
+#
+# /src is owned by the host user and we run as root, so git refuses it
+# as "dubious ownership" unless told otherwise. That refusal must not
+# be allowed to LOOK like a clean tree: `git status | wc -l` returns 0
+# both when the tree is clean and when git never ran, and recording
+# the second as `"dirty": false` is a false provenance claim. So we
+# clear the ownership check first, then treat an unusable git as
+# UNKNOWN — never as clean.
+git config --global --add safe.directory "$SRC" 2>/dev/null || true
+
+if git -C "$SRC" rev-parse --git-dir >/dev/null 2>&1; then
+  COMMIT=$(git -C "$SRC" rev-parse --short HEAD)
+  # No pipefail trap here: `git status` failing mid-pipeline would
+  # otherwise kill the script with an exit code and no message.
+  DIRTY=$(git -C "$SRC" status --porcelain | wc -l | tr -d ' ')
+  [ "$DIRTY" = "0" ] && DIRTYB=false || DIRTYB=true
+else
+  COMMIT=unknown
+  DIRTYB=null          # JSON null — "not known", distinct from false
+  echo "  NOTE  $SRC is not a usable git repo — provenance records dirty: null"
+fi
+
+# The release path sets CK_REQUIRE_CLEAN=1; bench builds default to
+# recording the truth and carrying on, because building uncommitted
+# work is the normal development case.
+if [ "${CK_REQUIRE_CLEAN:-0}" = "1" ] && [ "$DIRTYB" != "false" ]; then
+  die "CK_REQUIRE_CLEAN=1 and the tree is dirty or unattributable (dirty: $DIRTYB)"
+fi
+
+# ---- toolchain resolution (§3) --------------------------------------------
+# EXACT pin from Cargo.lock, never a caret: a range resolves against
+# whatever is published at build time and drifts from the crate silently.
+PIN=$(awk '/^name = "pgrx"$/{f=1;next} f&&/^version/{gsub(/[",]/,"");print $3;exit}' "$SRC/Cargo.lock" 2>/dev/null || true)
+[ -n "$PIN" ] || die "could not resolve the pgrx pin from $SRC/Cargo.lock"
+
+RUSTC=$(rustc --version | awk '{print $2}')
+say "extension" "$EXT $VER"
+say "commit" "$COMMIT (dirty: $DIRTYB)"
+say "pgrx pin" "$PIN"
+say "rustc" "$RUSTC"
+say "pg_major" "$PG_MAJOR"
+
+PGRX_ROOT="/pgrx/cargo-pgrx-${PIN}"
+if [ ! -x "${PGRX_ROOT}/bin/cargo-pgrx" ]; then
+  echo "  installing cargo-pgrx =${PIN} (version-scoped, cached)"
+  cargo install cargo-pgrx --locked --version "=${PIN}" --root "${PGRX_ROOT}"
+else
+  say "cargo-pgrx" "cached at ${PGRX_ROOT}"
+fi
+export PATH="${PGRX_ROOT}/bin:$PATH"
+
+mkdir -p "${PGRX_HOME:-/pgrx/home}"
+if [ ! -f "${PGRX_HOME:-/pgrx/home}/config.toml" ]; then
+  cargo pgrx init "--pg${PG_MAJOR}" "$(command -v pg_config)"
+fi
+
+# ---- build ----------------------------------------------------------------
+# Build identity, injected at compile time as <EXT>_BUILD_ID (PGRDF_BUILD_ID,
+# PGCK_BUILD_ID, ...). A crate that reads it can answer "which build is this"
+# from inside SQL; one that ignores it is unaffected. Deliberately carries
+# only tag/commits-since/short-commit/dirty — no paths, host or user, because
+# any connected role can read it.
+if [ "$COMMIT" != "unknown" ]; then
+  BUILD_ID=$(git -C "$SRC" describe --tags --always --dirty 2>/dev/null || echo "$COMMIT")
+else
+  BUILD_ID=unknown
+fi
+BUILD_ID_VAR="$(printf '%s' "$EXT" | tr '[:lower:]-' '[:upper:]_')_BUILD_ID"
+export "$BUILD_ID_VAR=$BUILD_ID"
+say "build id" "$BUILD_ID  (as \$$BUILD_ID_VAR)"
+
+cd "$SRC"
+
+if [ "$MODE" = "test" ]; then
+  say "mode" "test — running the pgrx suite, delivering nothing"
+  # `initdb` refuses to run as root, and this container is root. CI never hits
+  # it because a GitHub runner is already unprivileged; here the suite would
+  # fail 296 tests on one initdb refusal, every downstream test reporting
+  # "could not obtain test mutex" rather than the actual cause.
+  #
+  # pgrx supports an unprivileged run via CARGO_PGRX_TEST_RUNAS; the image
+  # provisions `postgres` with NOPASSWD sudo for exactly this. PGDATA moves off
+  # the root-owned /target volume so the sudo'd mkdir can write.
+  export CARGO_PGRX_TEST_RUNAS=postgres
+  export CARGO_PGRX_TEST_PGDATA=/tmp/pgrx-pgdata
+  mkdir -p "$CARGO_PGRX_TEST_PGDATA"
+  chown -R postgres:postgres "$CARGO_PGRX_TEST_PGDATA"
+  chmod -R a+rX "${PGRX_HOME:-/pgrx/home}" 2>/dev/null || true
+  say "runas" "postgres (initdb cannot run as root)"
+  cargo pgrx test --no-default-features --features "pg${PG_MAJOR}" "pg${PG_MAJOR}"
+  exit $?
+fi
+
+cargo pgrx package --pg-config "$(command -v pg_config)"
+
+PKG="${CARGO_TARGET_DIR:-/target}/release/${EXT}-pg${PG_MAJOR}"
+SO="${PKG}/usr/lib/postgresql/${PG_MAJOR}/lib/${EXT}.so"
+SHARE="${PKG}/usr/share/postgresql/${PG_MAJOR}/extension"
+[ -f "$SO" ] || die "no .so produced at $SO"
+
+# ---- delivery (§5) --------------------------------------------------------
+# .so and SQL move together or not at all: a binary whose catalog entry
+# is a different generation gives mismatched function arities.
+STAGE=$(mktemp -d "${OUT}/.ck-build.XXXXXX")
+trap 'rm -rf "$STAGE"' EXIT
+mkdir -p "$STAGE/lib" "$STAGE/share/extension"
+cp "$SO" "$STAGE/lib/${EXT}.so"
+cp "$SHARE/${EXT}.control" "$STAGE/share/extension/"
+cp "$SHARE"/*.sql "$STAGE/share/extension/"
+
+( cd "$STAGE/lib" && sha256sum "${EXT}.so" > "${EXT}.so.sha256" )
+DIGEST=$(awk '{print $1}' "$STAGE/lib/${EXT}.so.sha256")
+
+cat > "$STAGE/${EXT}.build.json" <<EOF
+{
+  "extension": "${EXT}",
+  "version": "${VER}",
+  "commit": "${COMMIT}",
+  "dirty": ${DIRTYB},
+  "pgrx": "${PIN}",
+  "rustc": "${RUSTC}",
+  "build_id": "${BUILD_ID}",
+  "base": "debian-13-trixie",
+  "pg_major": ${PG_MAJOR},
+  "so_sha256": "${DIGEST}",
+  "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+mkdir -p "$OUT/lib" "$OUT/share/extension"
+mv -f "$STAGE/lib/${EXT}.so" "$STAGE/lib/${EXT}.so.sha256" "$OUT/lib/"
+mv -f "$STAGE/share/extension/"* "$OUT/share/extension/"
+mv -f "$STAGE/${EXT}.build.json" "$OUT/"
+
+echo
+say "so" "$(stat -c%s "$OUT/lib/${EXT}.so") bytes"
+say "sha256" "${DIGEST:0:16}"
+say "delivered" "$OUT/lib/${EXT}.so + share/extension + build.json"
+[ "$DIRTYB" = "false" ] || echo "  NOTE  dirty: $DIRTYB — this artifact is not attributable to a commit"
+exit 0

--- a/compose/rust-builder.Containerfile
+++ b/compose/rust-builder.Containerfile
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1.4
+#
+# ck-rust-builder — the shared Rust builder, per SPEC.RUST-BUILDER.CK.v3.11.
+#
+# One image for every Rust artifact that loads into pgck-localhost.
+# Unlike compose/builder.Containerfile (pgRDF-only, source COPYed in at
+# BUILD time), this image contains NO source and NO cargo-pgrx: the
+# repo arrives as a read-only mount at RUN time and the entrypoint
+# resolves cargo-pgrx from that crate's own pin.
+#
+# Why cargo-pgrx is not baked: it must EXACTLY equal the crate's pgrx
+# pin. pgRDF is on 0.19.2 and pgCK on 0.16.1, so a baked version locks
+# the image to one crate. Resolving per build lets both share it today.
+#
+#   docker build -t ck-rust-builder:trixie-pg18 -f compose/rust-builder.Containerfile .
+#
+# See the entrypoint for the run-time contract.
+
+FROM docker.io/library/rust:1.97.1-trixie
+
+ARG PG_MAJOR=18
+ENV PG_MAJOR=${PG_MAJOR}
+
+# Postgres dev headers + full server (initdb, for crates that run
+# pgrx tests) and sudo for the pgrx-tests RUNAS path. Same pgdg setup
+# as the pgRDF builder — the userland here, not the host, determines
+# the .so's glibc floor, and trixie is what ck-allinone runs.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg lsb-release git jq \
+        build-essential pkg-config libssl-dev libclang-dev \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        postgresql-server-dev-${PG_MAJOR} \
+        postgresql-${PG_MAJOR} \
+        sudo \
+    && echo 'postgres ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/postgres-nopasswd \
+    && rm -rf /var/lib/apt/lists/*
+
+# PGRX_HOME and the version-scoped cargo-pgrx root are both cache
+# volumes at run time (see the spec §4), so multiple pgrx pins coexist
+# and a cold install happens once per fleet rather than once per repo.
+ENV PGRX_HOME=/pgrx/home \
+    CARGO_TARGET_DIR=/target
+
+COPY compose/rust-builder-entrypoint.sh /usr/local/bin/ck-build
+RUN chmod +x /usr/local/bin/ck-build
+
+WORKDIR /src
+ENTRYPOINT ["/usr/local/bin/ck-build"]

--- a/pgrdf.control
+++ b/pgrdf.control
@@ -17,7 +17,19 @@
 
 comment = 'Rust-native PostgreSQL extension for RDF, SPARQL, SHACL and OWL reasoning'
 default_version = '0.6.22'
-module_pathname = '$libdir/pgrdf'
+# Bare name, NOT '$libdir/pgrdf'. PostgreSQL resolves a module_pathname
+# containing a separator directly against pkglibdir and never consults
+# `dynamic_library_path`; only a bare name is searched along it. With the
+# '$libdir/' prefix a .so placed in an override directory is unreachable no
+# matter how the path is ordered — measured:
+#
+#   SET dynamic_library_path = '/nonexistent';
+#   LOAD 'pgcrypto';         -- ERROR: could not access file
+#   LOAD '$libdir/pgcrypto'; -- LOAD  (bypassed the path entirely)
+#
+# Backward compatible: the default `dynamic_library_path` is '$libdir', so a
+# bare name resolves to exactly the same file on a stock install.
+module_pathname = 'pgrdf'
 relocatable = false
 superuser = true
 trusted = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,29 @@ fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+/// Returns which BUILD of [`version`] this binary is.
+///
+/// `version()` reports the release line and is identical for every build of
+/// that version — two binaries differing by a merged fix both answer
+/// `0.6.22`. That makes it useless for the one question asked after loading a
+/// new `.so`: *is the module I just dropped the one now running?* This answers
+/// it, so a new module is distinguishable from the one it replaced without
+/// reading a digest off disk.
+///
+/// Set at compile time from `git describe --tags --always --dirty`, e.g.
+/// `v0.6.22-2-gab92a33-dirty`. `unknown` means the build did not supply one —
+/// never assume that is the same as clean.
+///
+/// **Deliberately narrow.** Any connected role can call this, so it carries
+/// only tag, commits-since, short commit and a dirty marker: no filesystem
+/// paths, host names, or build users. `build_id_carries_no_paths` enforces
+/// that rather than leaving it to review.
+#[search_path(pgrdf, pg_temp)]
+#[pg_extern]
+fn build_id() -> &'static str {
+    option_env!("PGRDF_BUILD_ID").unwrap_or("unknown")
+}
+
 extension_sql_file!("../sql/schema_v0_2_0.sql", name = "schema_v0_2_0");
 // v0.4 — adds `_pgrdf_graphs` IRI ↔ graph_id mapping (LLD v0.4 §3.1).
 // `requires` enforces ordering: the v0.2 baseline lands first; the
@@ -111,6 +134,28 @@ mod tests {
     #[pg_test]
     fn test_version_matches_cargo() {
         assert_eq!(crate::version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    /// `build_id()` is readable by any connected role, so the disclosure
+    /// constraint is a test rather than a comment. A build id that leaked a
+    /// build path would publish the operator's filesystem layout to every
+    /// user of the database.
+    #[test]
+    fn build_id_carries_no_paths() {
+        let id = crate::build_id();
+        assert!(!id.is_empty(), "build_id must never be empty");
+        for bad in ['/', '\\'] {
+            assert!(
+                !id.contains(bad),
+                "build_id must not carry filesystem paths, found {bad:?} in {id:?}"
+            );
+        }
+        // `git describe` output and the `unknown` fallback are both single
+        // tokens. Whitespace means something else got interpolated.
+        assert!(
+            !id.contains(char::is_whitespace),
+            "build_id must be a single token, got {id:?}"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #92.

## `build_id()`

```sql
SELECT pgrdf.version();    -- 0.6.22                      release line
SELECT pgrdf.build_id();   -- v0.6.22-2-gab92a33-dirty    which build
```

Compile-time from `git describe --tags --always --dirty` via `PGRDF_BUILD_ID`. `build.rs` carries `rerun-if-env-changed` — without it cargo would not recompile when the id changes, so a rebuild would keep the previous value. That is worse than having none: it would name a build that is not the one loaded.

**Narrow by design.** Any connected role can call it, so it carries tag / commits-since / short commit / dirty marker only — no filesystem paths, host names or build users. `build_id_carries_no_paths` enforces that as a test.

`version()` is unchanged and stays plain semver: it names the SQL file, drives `ALTER EXTENSION ... UPDATE`, and cannot contain `--`.

## Bare `module_pathname`

```
- module_pathname = '$libdir/pgrdf'
+ module_pathname = 'pgrdf'
```

PostgreSQL resolves a `module_pathname` containing a separator directly against `pkglibdir` and never consults `dynamic_library_path`. Measured:

```sql
SET dynamic_library_path = '/nonexistent';
LOAD 'pgcrypto';           -- ERROR: could not access file
LOAD '$libdir/pgcrypto';   -- LOAD  (bypassed the path entirely)
```

A `.so` in an override directory was therefore unreachable however the path was ordered — silently loading the original.

Backward compatible: the default `dynamic_library_path` is `$libdir`, so a bare name resolves to the same file on a stock install. **346 `pg_test`s pass, each running `CREATE EXTENSION`**, so resolution is exercised rather than asserted.

## Shared Rust builder

`compose/rust-builder.Containerfile` + entrypoint — one trixie/PG18 image both pgRDF and pgCK can build through. New files, referenced by no workflow; the release path is untouched and keeps its native-arch matrix.

`cargo-pgrx` is **not** baked: it must exactly equal the crate's `pgrx` pin and the two crates pin different versions, so the entrypoint resolves it per build from the crate's own `Cargo.lock` into a version-scoped root. Each artifact ships with a `.so.sha256` sidecar and a `build.json`.

Its `test` mode sets `CARGO_PGRX_TEST_RUNAS=postgres` — `initdb` refuses to run as root, and without it the suite fails 296 tests on a single `initdb` refusal, every downstream test reporting `could not obtain test mutex` rather than the cause. CI never hits it because a runner is already unprivileged.

## Verification

```
cargo fmt --check                                     clean
cargo clippy --no-default-features --features pg18    -D warnings, clean
cargo pgrx test --features pg18 pg18                  346 passed, 0 failed
```