### PR TITLE
docs+tooling: pre-tag gate script, fix builder dirty detection

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -133,7 +133,11 @@ pgRDF cuts each release as a **PR** (so the version bump + CHANGELOG flip are re
 2. On a `release-v<new>` branch off `main`, reconcile the version across the **Rule 7 source set** (`Cargo.toml` + the `Cargo.lock` `pgrdf` entry + `pgrdf.control` `default_version` + `META.json` + the `compose/compose.yml` bind-mount + `tests/regression/expected/00-smoke.out`), and `git mv sql/pgrdf--0.5.1--<old>.sql sql/pgrdf--0.5.1--<new>.sql` (version-string rename; the upgrade path carries no DDL unless a schema change shipped).
 3. Flip `CHANGELOG.md` `[Unreleased]` → `[<new>]` with the per-task entries that close the release — **at the cut, in this PR; never a separate post-merge changelog PR.** Refresh README / guide / compose install version refs (leave historical bench / feature attributions at their original version).
 4. Open the release PR — label `release`, milestone `v<new>`. CI is the boot+version reconciliation gate (the regression suite asserts `pgrdf.version() == <new>`). Merge on green (the merge is a human gate).
-5. Tag the merge commit (tagger `Peter Styk <peter@styk.tv>`): `git tag -a v<new> -F <annotated-message-file> <merge-sha>`; `git push origin v<new>`. Then delete the merged `release-v<new>` branch (branch-hygiene ritual above).
+5. **Run `scripts/pre-tag-check.sh <new>` on the merge commit** (`git checkout main && git pull` first — the merge commit is what gets tagged, and it is not always what you last tested). It replicates this workflow's pre-build assertions locally: the full Rule 7 source set, both upgrade scripts, the `0.5.1` bridge carrying the newer delta, the compose mount, the CHANGELOG section, `make check-meta`, Rule 4's prior-release check against `LATEST.md`, and a clean/pushed tree. Exit 0 is the go-ahead.
+
+   **Why this step exists:** `release.yml` refuses a mismatched tag, which is correct but expensive — the tag is already pushed by then, and a pushed tag is never reused. `v0.6.24` was burned exactly this way: `META.json` still read `0.6.22` while the tag said `0.6.24`. `META.json` is the one member of the Rule 7 set that a glob over `*.toml` / `*.control` / `*.yml` never reaches, so sweeping for version strings by filename silently skips it. Read this list; do not pattern-match it.
+
+6. Tag the merge commit (tagger `Peter Styk <peter@styk.tv>`): `git tag -a v<new> -F <annotated-message-file> <merge-sha>`; `git push origin v<new>`. Then delete the merged `release-v<new>` branch (branch-hygiene ritual above).
 
 GitHub Actions takes over:
 

--- a/compose/rust-builder-entrypoint.sh
+++ b/compose/rust-builder-entrypoint.sh
@@ -48,10 +48,34 @@ git config --global --add safe.directory "$SRC" 2>/dev/null || true
 
 if git -C "$SRC" rev-parse --git-dir >/dev/null 2>&1; then
   COMMIT=$(git -C "$SRC" rev-parse --short HEAD)
-  # No pipefail trap here: `git status` failing mid-pipeline would
-  # otherwise kill the script with an exit code and no message.
-  DIRTY=$(git -C "$SRC" status --porcelain | wc -l | tr -d ' ')
-  [ "$DIRTY" = "0" ] && DIRTYB=false || DIRTYB=true
+
+  # Dirtiness means TRACKED files differ from HEAD. Two container-specific
+  # traps make the naive check wrong in opposite ways:
+  #
+  # 1. `git status --porcelain` counts UNTRACKED files. The host's ignore
+  #    rules (global excludesFile, .git/info/exclude) do not come along
+  #    into the container, so files ignored on the host show up as `??`
+  #    here and every build reports dirty. That also makes
+  #    CK_REQUIRE_CLEAN refuse every release build.
+  #
+  # 2. /src is READ-ONLY, so git cannot write back a refreshed index.
+  #    Stat metadata differs across the mount, so `diff-index` reports
+  #    modifications for files whose contents are identical.
+  #
+  # Both are fixed by refreshing into a WRITABLE copy of the index and
+  # comparing tracked content only.
+  GIT_INDEX_COPY=/tmp/ck-build-index
+  if cp "$(git -C "$SRC" rev-parse --git-dir)/index" "$GIT_INDEX_COPY" 2>/dev/null; then
+    if GIT_INDEX_FILE="$GIT_INDEX_COPY" git -C "$SRC" update-index --refresh -q >/dev/null 2>&1 \
+       || true; then
+      GIT_INDEX_FILE="$GIT_INDEX_COPY" git -C "$SRC" diff-index --quiet HEAD -- \
+        && DIRTYB=false || DIRTYB=true
+    fi
+    rm -f "$GIT_INDEX_COPY"
+  else
+    # No readable index — do not guess. UNKNOWN, never clean.
+    DIRTYB=null
+  fi
 else
   COMMIT=unknown
   DIRTYB=null          # JSON null — "not known", distinct from false

--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Pre-tag gate — run this BEFORE `git push origin v<ver>`.
+#
+# It replicates release.yml's pre-build assertions locally, against the
+# working tree you are about to tag. `release.yml` refuses a mismatched tag,
+# which is correct but expensive: the tag is already pushed by then, and a
+# pushed tag is never reused (only-forward-never-revert). v0.6.24 was burned
+# exactly this way — META.json still read 0.6.22 while the tag said 0.6.24.
+#
+# META.json is the reason this script exists. It is a documented member of
+# the Rule 7 source set (PROVENANCE.md, "Cutting a release" step 2), and it
+# is the one member a glob over *.toml / *.control / *.yml never reaches --
+# so sweeping for version strings by filename silently skips it.
+#
+# Run it on the MERGE COMMIT, not the release branch: the merge commit is
+# what gets tagged, and it is not always what you last tested.
+#
+#   git checkout main && git pull
+#   scripts/pre-tag-check.sh 0.6.25
+#
+# Exit 0 = safe to tag. Non-zero = do not tag; fix and re-run.
+set -uo pipefail
+
+TAG_VER="${1:-}"
+if [ -z "$TAG_VER" ]; then
+  echo "usage: scripts/pre-tag-check.sh <version>   e.g. 0.6.25 (no leading v)" >&2
+  exit 2
+fi
+case "$TAG_VER" in v*) echo "pass the bare version, not the tag name (0.6.25, not v0.6.25)" >&2; exit 2;; esac
+
+FAIL=0
+ok(){   printf '  OK    %-24s %s\n' "$1" "$2"; }
+bad(){  printf '  FAIL  %-24s %s\n' "$1" "$2"; FAIL=1; }
+chk(){  if [ "$2" = "$TAG_VER" ]; then ok "$1" "$2"; else bad "$1" "$2 != $TAG_VER"; fi; }
+
+echo "pre-tag gate · v${TAG_VER} · $(git rev-parse --short HEAD) on $(git branch --show-current)"
+echo
+
+# --- Rule 7 source set (PROVENANCE.md "Cutting a release" step 2) ----------
+chk "Cargo.toml"         "$(grep -m1 '^version'         Cargo.toml    | cut -d'"' -f2)"
+chk "Cargo.lock (pgrdf)" "$(grep -A1 '^name = "pgrdf"$' Cargo.lock    | tail -1 | cut -d'"' -f2)"
+chk "pgrdf.control"      "$(grep -m1 '^default_version' pgrdf.control | cut -d\' -f2)"
+chk "META.json top"      "$(python3 -c "import json;print(json.load(open('META.json'))['version'])" 2>/dev/null)"
+chk "META.json provides" "$(python3 -c "import json;print(json.load(open('META.json'))['provides']['pgrdf']['version'])" 2>/dev/null)"
+chk "smoke golden"       "$(head -1 tests/regression/expected/00-smoke.out)"
+
+# --- artifacts the version implies ----------------------------------------
+if compgen -G "sql/pgrdf--*--${TAG_VER}.sql" >/dev/null; then
+  ok "upgrade scripts" "$(ls sql/pgrdf--*--${TAG_VER}.sql | xargs -n1 basename | tr '\n' ' ')"
+else
+  bad "upgrade scripts" "no sql/pgrdf--*--${TAG_VER}.sql"
+fi
+
+# Every bridge must land a COMPLETE release. Postgres takes the SHORTEST
+# update path, so an install on 0.5.1 reads the 0.5.1 bridge and never sees
+# the newer script -- a bridge renamed forward without replaying the delta
+# lands version-correct but function-incomplete.
+NEWEST=$(ls sql/pgrdf--*--${TAG_VER}.sql 2>/dev/null | grep -v -- '--0\.5\.1--' | head -1)
+BRIDGE=$(ls sql/pgrdf--0.5.1--${TAG_VER}.sql 2>/dev/null | head -1)
+if [ -n "$NEWEST" ] && [ -n "$BRIDGE" ]; then
+  MISSING=""
+  while read -r fn; do
+    grep -q "$fn" "$BRIDGE" || MISSING="$MISSING $fn"
+  done < <(grep -oE 'CREATE (OR REPLACE )?FUNCTION "[a-z_]+"' "$NEWEST" | sort -u)
+  [ -z "$MISSING" ] && ok "0.5.1 bridge complete" "carries the newer delta" \
+                    || bad "0.5.1 bridge" "missing:$MISSING"
+fi
+
+grep -q "pgrdf--${TAG_VER}.sql" compose/compose.yml \
+  && ok  "compose mount" "pgrdf--${TAG_VER}.sql" \
+  || bad "compose mount" "not bumped"
+
+grep -q "^## \[${TAG_VER}\]" CHANGELOG.md \
+  && ok  "CHANGELOG" "[${TAG_VER}] section present" \
+  || bad "CHANGELOG" "no [${TAG_VER}] section — the tag body renders from Unreleased at tag time"
+
+make check-meta >/dev/null 2>&1 && ok "make check-meta" "pass" || bad "make check-meta" "fail"
+
+# --- Rule 4: the PREVIOUS release must be advertised before tagging a new one
+PREV=$(grep -m1 -oE 'v0\.[0-9]+\.[0-9]+' LATEST.md 2>/dev/null | head -1)
+[ -n "$PREV" ] && ok "LATEST.md advertises" "$PREV (Rule 4 — must be the prior release)" \
+               || bad "LATEST.md" "could not read a version"
+
+# --- tree state -----------------------------------------------------------
+D=$(git status --short | wc -l | tr -d ' '); U=$(git log @{u}.. --oneline 2>/dev/null | wc -l | tr -d ' ')
+[ "$D" = "0" ] && ok "tree clean" "0 uncommitted" || bad "tree dirty" "$D uncommitted"
+[ "$U" = "0" ] && ok "pushed" "0 unpushed"        || bad "unpushed" "$U commit(s)"
+
+echo
+if [ $FAIL -eq 0 ]; then
+  echo "  PASS — safe to: git tag -a v${TAG_VER} -F <annotation> $(git rev-parse --short HEAD)"
+else
+  echo "  FAIL — do NOT tag. A pushed tag is never reused; fix and re-run."
+fi
+exit $FAIL


### PR DESCRIPTION
Docs + tooling only — no version bump, no release, per "One code merge → one version".

Two builder/release-process fixes, both found by questions asked after `v0.6.25` shipped.

## 1. `scripts/pre-tag-check.sh` — the gate that would have saved `v0.6.24`

`v0.6.24` was burned because `META.json` still read `0.6.22` while the tag said `0.6.24`. `release.yml` caught it correctly, but only **after** the tag was pushed — and a pushed tag is never reused.

Replicates the pre-build assertions locally, plus what only a human was checking:

- the full **Rule 7 source set, including `META.json`** (both fields)
- upgrade scripts exist for the target version
- **the `0.5.1` bridge carries the newer delta** — PostgreSQL takes the *shortest* update path, so a bridge renamed forward without replaying the delta lands an install version-correct but function-incomplete
- compose mount, CHANGELOG section, `make check-meta`
- **Rule 4** — `LATEST.md` advertises the *prior* release
- tree clean and pushed

Run on the **merge commit**, which is what gets tagged.

`PROVENANCE.md` gains it as step 5. The protocol **already listed `META.json`** in step 2 — the failure was sweeping for version strings by filename, and `*.toml`/`*.control`/`*.yml` never reaches it.

## 2. `dirty` detection was wrong in both directions

Asking "was the bench built from the released commit?" exposed this:

```
build.json   dirty: true      <- counted an untracked file + stale-index stat noise
build_id()   no -dirty        <- git describe counts neither
```

Two container-specific causes:

- `git status --porcelain` counts **untracked** files, and the host's ignore rules do not follow the mount into the container — so a host-ignored file appears as `??` and **every** build reported dirty. `CK_REQUIRE_CLEAN=1` would have refused every release build.
- `/src` is read-only, so git cannot write back a refreshed index; stat metadata differs across the mount and `diff-index` reports modifications for identical content.

Net effect: the SQL-visible plane disagreed with the provenance record — precisely what `build_id()` exists to detect. It was lying about itself.

Now refreshes into a writable **copy** of the index and compares tracked content only; an unreadable index records `null`, never `false`.

Verified after the fix — the bench rebuilt from the tagged commit reports:

```
commit f4a21c6 == git rev-list -n1 v0.6.25 · dirty false · build_id v0.6.25
```