### PR TITLE
chore(release): 0.6.33 — META.json version fields (pre-tag gate catch)

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
   "name": "pgrdf",
   "abstract": "Rust-native PostgreSQL extension for RDF, SPARQL, SHACL and OWL reasoning",
   "description": "pgRDF turns one PostgreSQL instance into a complete semantic-web engine — dictionary-encoded hexastore storage, a SPARQL 1.1 query and update engine, a W3C-conformant SHACL Core validator (25/25), and an OWL 2 RL / RDFS reasoner — with no sidecar triple store and no second system to operate. Load Turtle, TriG or N-Quads, then reason over it, validate it, and query it in place, each step a single function call inside one PostgreSQL session. Supports PostgreSQL 14–18; every release is CI-built and signed with SLSA Build Provenance v1.",
-  "version": "0.6.32",
+  "version": "0.6.33",
   "maintainer": [
     "Peter Styk"
   ],
@@ -13,7 +13,7 @@
       "abstract": "Rust-native PostgreSQL extension for RDF, SPARQL, SHACL and OWL reasoning",
       "file": "pgrdf.control",
       "docfile": "README.pgxn.md",
-      "version": "0.6.32"
+      "version": "0.6.33"
     }
   },
   "prereqs": {


### PR DESCRIPTION
Two-line follow-up to #128: the release chore missed META.json's top-level and `provides` version fields; `scripts/pre-tag-check.sh 0.6.33` failed exactly there (everything else OK). `make check-meta` passes with the bump. Tag `v0.6.33` waits on this.